### PR TITLE
Add non-interactive flags for deploy, clone, and create commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 cli
 major
+major-dev

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,21 @@
-.PHONY: rerelease release
+.PHONY: rerelease release dev-install dev-restore
+
+# Build and install locally for development
+dev-install:
+	@echo "Building CLI with prod config..."
+	go build -ldflags "-X 'github.com/major-technology/cli/cmd.configFile=configs/prod.json'" -o major .
+	@echo "Backing up current CLI..."
+	@cp ~/.major/bin/major ~/.major/bin/major.backup 2>/dev/null || true
+	@echo "Installing development build..."
+	@cp major ~/.major/bin/major
+	@rm major
+	@echo "Done! Run 'major --version' to verify."
+
+# Restore original CLI from backup
+dev-restore:
+	@echo "Restoring original CLI..."
+	@cp ~/.major/bin/major.backup ~/.major/bin/major
+	@echo "Done!"
 
 rerelease:
 	@echo "Releasing version v$(VERSION)..."

--- a/clients/api/client.go
+++ b/clients/api/client.go
@@ -438,3 +438,20 @@ func (c *Client) GetApplicationForLink(applicationID string) (*GetApplicationFor
 	}
 	return &resp, nil
 }
+
+// PushTemplate pushes template files to the application repository using backend GitHub App credentials
+// This bypasses the need for user's SSH access, allowing template push even when
+// the user hasn't accepted the GitHub invitation yet.
+func (c *Client) PushTemplate(applicationID, templateID string) (*PushTemplateResponse, error) {
+	req := PushTemplateRequest{
+		ApplicationID: applicationID,
+		TemplateID:    templateID,
+	}
+
+	var resp PushTemplateResponse
+	err := c.doRequest("POST", "/applications/push-template", req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/clients/api/structs.go
+++ b/clients/api/structs.go
@@ -300,3 +300,20 @@ type GetApplicationForLinkResponse struct {
 	CloneURLSSH      string          `json:"cloneUrlSsh,omitempty"`
 	CloneURLHTTPS    string          `json:"cloneUrlHttps,omitempty"`
 }
+
+// --- Push Template structs ---
+
+// PushTemplateRequest represents the request body for POST /applications/push-template
+type PushTemplateRequest struct {
+	ApplicationID string `json:"applicationId"`
+	TemplateID    string `json:"templateId"`
+}
+
+// PushTemplateResponse represents the response from POST /applications/push-template
+type PushTemplateResponse struct {
+	Error      *AppErrorDetail `json:"error,omitempty"`
+	Success    bool            `json:"success"`
+	CommitSha  string          `json:"commitSha,omitempty"`
+	FilesCount int             `json:"filesCount,omitempty"`
+	ErrorMsg   string          `json:"errorMessage,omitempty"`
+}

--- a/cmd/app/create.go
+++ b/cmd/app/create.go
@@ -19,10 +19,9 @@ import (
 
 // Flag variables for non-interactive mode
 var (
-	flagAppName         string
-	flagAppDescription  string
-	flagTemplate        string
-	flagCreateGithubUser string
+	flagAppName        string
+	flagAppDescription string
+	flagTemplate       string
 )
 
 // createCmd represents the create command
@@ -51,7 +50,7 @@ func init() {
 	createCmd.Flags().StringVar(&flagAppName, "name", "", "Application name (skips interactive prompt)")
 	createCmd.Flags().StringVar(&flagAppDescription, "description", "", "Application description (skips interactive prompt)")
 	createCmd.Flags().StringVar(&flagTemplate, "template", "", "Template name: 'Vite' or 'NextJS' (skips interactive prompt)")
-	createCmd.Flags().StringVar(&flagCreateGithubUser, "github-user", "", "GitHub username for repository access (for non-interactive mode)")
+	createCmd.Flags().StringVar(&flagGithubUser, "github-user", "", "GitHub username for repository access (for non-interactive mode)")
 }
 
 func runCreate(cobraCmd *cobra.Command) error {
@@ -164,7 +163,7 @@ func runCreate(cobraCmd *cobra.Command) error {
 	isNonInteractive := flagAppName != "" && flagAppDescription != "" && flagTemplate != ""
 	opts := utils.EnsureRepositoryAccessOptions{
 		NonInteractive: isNonInteractive,
-		GithubUsername: flagCreateGithubUser,
+		GithubUsername: flagGithubUser,
 	}
 	err = utils.EnsureRepositoryAccessWithOptions(cobraCmd, createResp.ApplicationID, createResp.CloneURLSSH, createResp.CloneURLHTTPS, opts)
 

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -57,6 +57,9 @@ func runDeploy(cobraCmd *cobra.Command) error {
 
 		// Use flag if provided, otherwise prompt interactively
 		if flagDeployMessage != "" {
+			if strings.TrimSpace(flagDeployMessage) == "" {
+				return fmt.Errorf("commit message cannot be empty or whitespace only")
+			}
 			commitMessage = flagDeployMessage
 		} else {
 			// Interactive prompt for commit message

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -15,6 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Flag variables for non-interactive mode
+var flagDeployMessage string
+
+func init() {
+	deployCmd.Flags().StringVarP(&flagDeployMessage, "message", "m", "", "Commit message for uncommitted changes (skips interactive prompt)")
+}
+
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
@@ -46,25 +53,31 @@ func runDeploy(cobraCmd *cobra.Command) error {
 	if hasChanges {
 		cobraCmd.Println("📝 Uncommitted changes detected")
 
-		// Prompt for commit message
 		var commitMessage string
-		form := huh.NewForm(
-			huh.NewGroup(
-				huh.NewText().
-					Title("Commit Message").
-					Description("Enter a commit message for your changes").
-					Value(&commitMessage).
-					Validate(func(s string) error {
-						if strings.TrimSpace(s) == "" {
-							return fmt.Errorf("commit message is required")
-						}
-						return nil
-					}),
-			),
-		)
 
-		if err := form.Run(); err != nil {
-			return errors.WrapError("failed to collect commit message", err)
+		// Use flag if provided, otherwise prompt interactively
+		if flagDeployMessage != "" {
+			commitMessage = flagDeployMessage
+		} else {
+			// Interactive prompt for commit message
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewText().
+						Title("Commit Message").
+						Description("Enter a commit message for your changes").
+						Value(&commitMessage).
+						Validate(func(s string) error {
+							if strings.TrimSpace(s) == "" {
+								return fmt.Errorf("commit message is required")
+							}
+							return nil
+						}),
+				),
+			)
+
+			if err := form.Run(); err != nil {
+				return errors.WrapError("failed to collect commit message", err)
+			}
 		}
 
 		// Stage all changes

--- a/cmd/app/helper.go
+++ b/cmd/app/helper.go
@@ -181,7 +181,8 @@ func ensureGitRepositoryWithRetries(cmd *cobra.Command, workingDir, sshURL, http
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
-			delay := baseDelay * time.Duration(1<<uint(attempt-1)) // Exponential backoff: 200ms, 400ms, 800ms
+			delay := baseDelay * time.Duration(1<<uint(attempt-1)) // Exponential backoff: 2s, 4s, 8s, 16s, 32s
+			cmd.Printf("Waiting %v for GitHub permissions to propagate...\n", delay)
 			time.Sleep(delay)
 		}
 

--- a/cmd/user/gitconfig.go
+++ b/cmd/user/gitconfig.go
@@ -9,14 +9,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flagGitconfigUsername string
+
 // gitconfigCmd represents the gitconfig command
 var gitconfigCmd = &cobra.Command{
 	Use:   "gitconfig",
 	Short: "Configure git settings",
-	Long:  `Configure git-related settings such as your GitHub username.`,
+	Long: `Configure git-related settings such as your GitHub username.
+
+You can provide the username via flag for non-interactive usage:
+
+  major user gitconfig --username "your-github-username"`,
 	RunE: func(cobraCmd *cobra.Command, args []string) error {
 		return runGitConfig(cobraCmd)
 	},
+}
+
+func init() {
+	gitconfigCmd.Flags().StringVar(&flagGitconfigUsername, "username", "", "GitHub username to store (skips interactive prompt)")
 }
 
 func runGitConfig(cobraCmd *cobra.Command) error {
@@ -26,31 +36,37 @@ func runGitConfig(cobraCmd *cobra.Command) error {
 		return clierrors.WrapError("failed to get current GitHub username", err)
 	}
 
-	// Show current username if it exists
-	if currentUsername != "" {
-		cobraCmd.Printf("Current GitHub username: %s\n\n", currentUsername)
-	}
-
-	// Prompt for new GitHub username
 	var githubUsername string
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewInput().
-				Title("GitHub Username").
-				Description("Enter your GitHub username").
-				Value(&githubUsername).
-				Placeholder(currentUsername).
-				Validate(func(s string) error {
-					if s == "" {
-						return errors.New("GitHub username is required")
-					}
-					return nil
-				}),
-		),
-	)
 
-	if err := form.Run(); err != nil {
-		return clierrors.WrapError("failed to collect GitHub username", err)
+	// If username flag is provided, use it directly
+	if flagGitconfigUsername != "" {
+		githubUsername = flagGitconfigUsername
+	} else {
+		// Show current username if it exists
+		if currentUsername != "" {
+			cobraCmd.Printf("Current GitHub username: %s\n\n", currentUsername)
+		}
+
+		// Prompt for new GitHub username
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("GitHub Username").
+					Description("Enter your GitHub username").
+					Value(&githubUsername).
+					Placeholder(currentUsername).
+					Validate(func(s string) error {
+						if s == "" {
+							return errors.New("GitHub username is required")
+						}
+						return nil
+					}),
+			),
+		)
+
+		if err := form.Run(); err != nil {
+			return clierrors.WrapError("failed to collect GitHub username", err)
+		}
 	}
 
 	// Store the GitHub username

--- a/cmd/user/login.go
+++ b/cmd/user/login.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	apiClient "github.com/major-technology/cli/clients/api"
+	"github.com/major-technology/cli/clients/git"
 	mjrToken "github.com/major-technology/cli/clients/token"
 	clierrors "github.com/major-technology/cli/errors"
 	"github.com/major-technology/cli/singletons"
@@ -80,6 +81,17 @@ func doLogin(cobraCmd *cobra.Command, selectOrg bool) error {
 		} else {
 			return clierrors.ErrorNoOrganizationsAvailable
 		}
+	}
+
+	// Auto-detect and store GitHub username from SSH
+	cobraCmd.Println("\nDetecting GitHub configuration...")
+	githubUser, err := git.GetCurrentGithubUser()
+	if err == nil && githubUser != "" {
+		_ = mjrToken.StoreGithubUsername(githubUser)
+		cobraCmd.Printf("✓ GitHub username detected: %s\n", githubUser)
+	} else {
+		cobraCmd.Println("⚠ Could not detect GitHub username from SSH.")
+		cobraCmd.Println("  Run 'major user gitconfig' to set it manually.")
 	}
 
 	return nil

--- a/cmd/user/login.go
+++ b/cmd/user/login.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	apiClient "github.com/major-technology/cli/clients/api"
-	"github.com/major-technology/cli/clients/git"
 	mjrToken "github.com/major-technology/cli/clients/token"
 	clierrors "github.com/major-technology/cli/errors"
 	"github.com/major-technology/cli/singletons"
@@ -81,17 +80,6 @@ func doLogin(cobraCmd *cobra.Command, selectOrg bool) error {
 		} else {
 			return clierrors.ErrorNoOrganizationsAvailable
 		}
-	}
-
-	// Auto-detect and store GitHub username from SSH
-	cobraCmd.Println("\nDetecting GitHub configuration...")
-	githubUser, err := git.GetCurrentGithubUser()
-	if err == nil && githubUser != "" {
-		_ = mjrToken.StoreGithubUsername(githubUser)
-		cobraCmd.Printf("✓ GitHub username detected: %s\n", githubUser)
-	} else {
-		cobraCmd.Println("⚠ Could not detect GitHub username from SSH.")
-		cobraCmd.Println("  Run 'major user gitconfig' to set it manually.")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Add non-interactive flags to key CLI commands, enabling automation and AI tool integration.

### Deploy Command
- Add `-m`/`--message` flag to skip interactive commit prompt
- Auto-stages, commits, and pushes changes before deploying

### Clone Command  
- Add `--app-id` flag to clone by application ID without interactive selection
- Add `--github-user` flag for non-interactive GitHub username
- Improved GitHub invitation flow with clear user messaging

### Create Command
- Add `--name` flag for application name
- Add `--description` flag for application description
- Add `--template` flag (Vite, NextJS)
- Add `--github-user` flag for non-interactive mode

### Other Changes
- Makefile: Add `dev-install` and `dev-restore` targets for local development
- API client: New endpoints and structs for invitation handling
- Git helper: Improved retry logic and error handling
- User commands: Login and gitconfig improvements

## Test plan
- [ ] `major app deploy --message "test"` with uncommitted changes
- [ ] `major app deploy -m "test"` shorthand
- [ ] `major app clone --app-id "<id>"` non-interactive clone
- [ ] `major app create --name "test" --description "desc" --template "Vite"`
- [ ] Interactive fallback when flags not provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)