### PR TITLE
Add themes support on app init and startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 cli
 major
 major-dev
+.idea

--- a/clients/api/client.go
+++ b/clients/api/client.go
@@ -170,11 +170,12 @@ func (c *Client) GetOrganizations() (*OrganizationsResponse, error) {
 // --- Application endpoints ---
 
 // CreateApplication creates a new application with a GitHub repository
-func (c *Client) CreateApplication(name, description, organizationID string) (*CreateApplicationResponse, error) {
+func (c *Client) CreateApplication(name, description, organizationID string, themeID *string) (*CreateApplicationResponse, error) {
 	req := CreateApplicationRequest{
 		Name:           name,
 		Description:    description,
 		OrganizationID: organizationID,
+		ThemeID:        themeID,
 	}
 
 	var resp CreateApplicationResponse
@@ -412,5 +413,49 @@ func (c *Client) GetApplicationForLink(applicationID string) (*GetApplicationFor
 		return nil, err
 	}
 	return &resp, nil
+}
+
+// --- Theme endpoints ---
+
+// GetThemeFiles retrieves the generated theme files for an application
+func (c *Client) GetThemeFiles(applicationID string) (*GetThemeFilesResponse, error) {
+	path := fmt.Sprintf("/application/%s/theme-files", applicationID)
+	var resp GetThemeFilesResponse
+	err := c.doRequest("GET", path, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ListThemes retrieves all themes for an organization
+func (c *Client) ListThemes(orgID string) (*ListThemesResponse, error) {
+	path := fmt.Sprintf("/themes?organizationId=%s", orgID)
+	var resp ListThemesResponse
+	err := c.doRequest("GET", path, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetThemeVersion retrieves the theme version for an application
+func (c *Client) GetThemeVersion(applicationID string) (*GetThemeVersionResponse, error) {
+	path := fmt.Sprintf("/application/%s/theme-version", applicationID)
+	var resp GetThemeVersionResponse
+	err := c.doRequest("GET", path, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpgradeTheme bumps the app's theme version to the latest
+func (c *Client) UpgradeTheme(applicationID string) error {
+	path := fmt.Sprintf("/application/%s/upgrade-theme", applicationID)
+	var resp struct {
+		Error *AppErrorDetail `json:"error,omitempty"`
+	}
+	return c.doRequest("POST", path, struct{}{}, &resp)
 }
 

--- a/clients/api/structs.go
+++ b/clients/api/structs.go
@@ -51,9 +51,10 @@ type OrganizationsResponse struct {
 
 // CreateApplicationRequest represents the request body for POST /applications
 type CreateApplicationRequest struct {
-	Name           string `json:"name"`
-	Description    string `json:"description"`
-	OrganizationID string `json:"organizationId"`
+	Name           string  `json:"name"`
+	Description    string  `json:"description"`
+	OrganizationID string  `json:"organizationId"`
+	ThemeID        *string `json:"themeId,omitempty"`
 }
 
 // CreateApplicationResponse represents the response from POST /applications
@@ -272,5 +273,55 @@ type GetApplicationForLinkResponse struct {
 	Name             string          `json:"name,omitempty"`
 	CloneURLSSH      string          `json:"cloneUrlSsh,omitempty"`
 	CloneURLHTTPS    string          `json:"cloneUrlHttps,omitempty"`
+}
+
+// --- Theme structs ---
+
+// ThemeConfig represents the theme configuration
+type ThemeConfig struct {
+	BaseColor   interface{} `json:"baseColor"`
+	AccentTheme interface{} `json:"accentTheme"`
+	Font        string      `json:"font"`
+	Radius      string      `json:"radius"`
+	Elevation   string      `json:"elevation,omitempty"`
+}
+
+// ThemeDisplayColors contains resolved hex colors for terminal rendering.
+type ThemeDisplayColors struct {
+	BaseColorHex   *string `json:"baseColorHex,omitempty"`
+	AccentColorHex *string `json:"accentColorHex,omitempty"`
+}
+
+// ThemeItem represents a single theme
+type ThemeItem struct {
+	ID            string              `json:"id"`
+	Name          string              `json:"name"`
+	IsDefault     bool                `json:"isDefault"`
+	Config        ThemeConfig         `json:"config"`
+	DisplayColors *ThemeDisplayColors `json:"displayColors,omitempty"`
+}
+
+// ListThemesResponse represents the response from GET /themes
+type ListThemesResponse struct {
+	Error  *AppErrorDetail `json:"error,omitempty"`
+	Themes []ThemeItem     `json:"themes,omitempty"`
+}
+
+// GetThemeVersionResponse represents the response from GET /application/:applicationId/theme-version
+type GetThemeVersionResponse struct {
+	Error              *AppErrorDetail `json:"error,omitempty"`
+	AppThemeVersion    *int            `json:"appThemeVersion,omitempty"`
+	LatestThemeVersion *int            `json:"latestThemeVersion,omitempty"`
+	UpgradeAvailable   bool            `json:"upgradeAvailable"`
+}
+
+// GetThemeFilesResponse represents the response from GET /application/:applicationId/theme-files
+type GetThemeFilesResponse struct {
+	Error         *AppErrorDetail `json:"error,omitempty"`
+	Css           *string         `json:"css,omitempty"`
+	ThemeModule   *string         `json:"themeModule,omitempty"`
+	LogoComponent *string         `json:"logoComponent,omitempty"`
+	Skill         *string         `json:"skill,omitempty"`
+	Version       *int            `json:"version,omitempty"`
 }
 

--- a/cmd/app/create.go
+++ b/cmd/app/create.go
@@ -55,19 +55,23 @@ func runCreate(cobraCmd *cobra.Command) error {
 
 	cobraCmd.Printf("Creating application in organization: %s\n\n", orgName)
 
+	// Get the API client
+	apiClient := singletons.GetAPIClient()
+
 	// Use flag values if provided, otherwise prompt interactively
 	appName := flagAppName
 	appDescription := flagAppDescription
+	var selectedThemeID string
 
 	// Check if we need to prompt for any values
 	needsPrompt := appName == "" || appDescription == ""
 
 	if needsPrompt {
 		// Build form fields only for missing values
-		var formGroups []huh.Field
+		var formFields []huh.Field
 
 		if appName == "" {
-			formGroups = append(formGroups,
+			formFields = append(formFields,
 				huh.NewInput().
 					Title("Application Name").
 					Description("Enter a name for your application").
@@ -82,8 +86,8 @@ func runCreate(cobraCmd *cobra.Command) error {
 		}
 
 		if appDescription == "" {
-			formGroups = append(formGroups,
-				huh.NewText().
+			formFields = append(formFields,
+				huh.NewInput().
 					Title("Application Description").
 					Description("Enter a description for your application").
 					Value(&appDescription).
@@ -96,7 +100,18 @@ func runCreate(cobraCmd *cobra.Command) error {
 			)
 		}
 
-		form := huh.NewForm(huh.NewGroup(formGroups...))
+		// Add theme selection field
+		themeField, themeErr := buildThemeSelectField(apiClient, orgID, &selectedThemeID)
+
+		if themeErr != nil {
+			cobraCmd.Printf("Warning: Failed to load themes: %v\n", themeErr)
+		}
+
+		if themeField != nil {
+			formFields = append(formFields, themeField)
+		}
+
+		form := huh.NewForm(huh.NewGroup(formFields...))
 
 		if err := form.Run(); err != nil {
 			return errors.WrapError("failed to collect application details", err)
@@ -112,12 +127,16 @@ func runCreate(cobraCmd *cobra.Command) error {
 		return errors.ErrorApplicationDescriptionRequired
 	}
 
-	// Get the API client
-	apiClient := singletons.GetAPIClient()
+	// Convert theme ID to pointer for API call
+	var themeIDPtr *string
+
+	if selectedThemeID != "" {
+		themeIDPtr = &selectedThemeID
+	}
 
 	cobraCmd.Printf("\nCreating application '%s'...\n", appName)
 
-	createResp, err := apiClient.CreateApplication(appName, appDescription, orgID)
+	createResp, err := apiClient.CreateApplication(appName, appDescription, orgID, themeIDPtr)
 	if err != nil {
 		return err
 	}
@@ -194,6 +213,14 @@ func runCreate(cobraCmd *cobra.Command) error {
 		} else {
 			cobraCmd.Println("✓ Generated .mcp.json for Claude Code")
 		}
+	}
+
+	// Generate theme files
+	cobraCmd.Println("Generating theme files...")
+	if err := generateThemeFiles(targetDir); err != nil {
+		cobraCmd.Printf("Warning: Failed to generate theme files: %v\n", err)
+	} else {
+		cobraCmd.Println("✓ Theme files generated")
 	}
 
 	printSuccessMessage(cobraCmd, appName)

--- a/cmd/app/helper.go
+++ b/cmd/app/helper.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/major-technology/cli/clients/api"
 	"github.com/major-technology/cli/clients/git"
 	"github.com/major-technology/cli/errors"
 	"github.com/major-technology/cli/singletons"
@@ -246,4 +249,234 @@ func generateEnvFile(targetDir string) (string, map[string]string, error) {
 	}
 
 	return envFilePath, envVars, nil
+}
+
+// generateThemeFiles generates theme files (theme.css, theme.ts, logo.tsx) for the application.
+// If targetDir is empty, it uses the current git repository root.
+func generateThemeFiles(targetDir string) error {
+	applicationID, _, _, err := getApplicationAndOrgIDFromDir(targetDir)
+	if err != nil {
+		return errors.WrapError("failed to get application ID", err)
+	}
+
+	apiClient := singletons.GetAPIClient()
+
+	resp, err := apiClient.GetThemeFiles(applicationID)
+	if err != nil {
+		return errors.WrapError("failed to get theme files", err)
+	}
+
+	// No theme configured — not an error
+	if resp.Css == nil && resp.ThemeModule == nil {
+		return nil
+	}
+
+	gitRoot := targetDir
+	if gitRoot == "" {
+		gitRoot, err = git.GetRepoRoot()
+		if err != nil {
+			return errors.WrapError("failed to get git repository root", err)
+		}
+	}
+
+	// Write theme.css
+	if resp.Css != nil {
+		cssPath := filepath.Join(gitRoot, "app", "theme.css")
+
+		if err := os.MkdirAll(filepath.Dir(cssPath), 0755); err != nil {
+			return errors.WrapError("failed to create app directory", err)
+		}
+
+		if err := os.WriteFile(cssPath, []byte(*resp.Css), 0644); err != nil {
+			return errors.WrapError("failed to write theme.css", err)
+		}
+	}
+
+	// Write lib/theme.ts
+	if resp.ThemeModule != nil {
+		modulePath := filepath.Join(gitRoot, "lib", "theme.ts")
+		if err := os.MkdirAll(filepath.Dir(modulePath), 0755); err != nil {
+			return errors.WrapError("failed to create lib directory", err)
+		}
+
+		if err := os.WriteFile(modulePath, []byte(*resp.ThemeModule), 0644); err != nil {
+			return errors.WrapError("failed to write theme.ts", err)
+		}
+	}
+
+	// Write components/ui/logo.tsx
+	if resp.LogoComponent != nil {
+		logoPath := filepath.Join(gitRoot, "components", "ui", "logo.tsx")
+		if err := os.MkdirAll(filepath.Dir(logoPath), 0755); err != nil {
+			return errors.WrapError("failed to create components/ui directory", err)
+		}
+
+		if err := os.WriteFile(logoPath, []byte(*resp.LogoComponent), 0644); err != nil {
+			return errors.WrapError("failed to write logo.tsx", err)
+		}
+	}
+
+	// Write theme skill for Claude Code
+	if resp.Skill != nil {
+		skillPath := filepath.Join(gitRoot, ".claude", "skills", "theme", "SKILL.md")
+		if err := os.MkdirAll(filepath.Dir(skillPath), 0755); err != nil {
+			return errors.WrapError("failed to create .claude/skills/theme directory", err)
+		}
+
+		if err := os.WriteFile(skillPath, []byte(*resp.Skill), 0644); err != nil {
+			return errors.WrapError("failed to write theme skill", err)
+		}
+	}
+
+	return nil
+}
+
+// handleThemeSync writes theme files on first-time setup, and prompts for upgrade
+// if the app's theme version is behind the latest theme version.
+func handleThemeSync(cmd *cobra.Command) error {
+	applicationID, _, _, err := getApplicationAndOrgIDFromDir("")
+	if err != nil {
+		return err
+	}
+
+	gitRoot, err := git.GetRepoRoot()
+	if err != nil {
+		return err
+	}
+
+	existingCssPath := filepath.Join(gitRoot, "app", "theme.css")
+
+	// First-time setup — write without prompting
+	if _, statErr := os.Stat(existingCssPath); os.IsNotExist(statErr) {
+		if err := generateThemeFiles(""); err != nil {
+			return err
+		}
+
+		cmd.Println("✓ Theme files generated")
+		return nil
+	}
+
+	// Check if upgrade is available
+	apiClient := singletons.GetAPIClient()
+
+	versionResp, err := apiClient.GetThemeVersion(applicationID)
+	if err != nil {
+		return nil // Non-fatal — skip version check
+	}
+
+	if !versionResp.UpgradeAvailable || versionResp.AppThemeVersion == nil || versionResp.LatestThemeVersion == nil {
+		return nil
+	}
+
+	// Prompt for upgrade
+	var confirm bool
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("Theme upgrade available (v%d → v%d). Apply?",
+					*versionResp.AppThemeVersion, *versionResp.LatestThemeVersion)).
+				Value(&confirm),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		return err
+	}
+
+	if confirm {
+		// Bump the version in the database first
+		if err := apiClient.UpgradeTheme(applicationID); err != nil {
+			return errors.WrapError("failed to upgrade theme", err)
+		}
+
+		// Then write theme files at the new version
+		if err := generateThemeFiles(""); err != nil {
+			return err
+		}
+
+		cmd.Println("✓ Theme files upgraded")
+	}
+
+	return nil
+}
+
+// renderColorBlock renders a colored █ block from a hex string, or plain █ if nil.
+func renderColorBlock(hex *string) string {
+	if hex == nil || *hex == "" {
+		return "█"
+	}
+
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(*hex)).Render("█")
+}
+
+// dimText renders text in gray for secondary info.
+func dimText(s string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("#888888")).Render(s)
+}
+
+// buildThemeSelectField builds a huh.Select field for theme selection.
+// Returns the field and a pointer to the selected value. Returns nil if no themes available.
+func buildThemeSelectField(apiClient *api.Client, orgID string, selectedID *string) (huh.Field, error) {
+	resp, err := apiClient.ListThemes(orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Themes) == 0 {
+		return nil, nil
+	}
+
+	options := make([]huh.Option[string], 0, len(resp.Themes)+1)
+
+	// "Use default" option first, pre-selected
+	var defaultThemeName string
+
+	for _, t := range resp.Themes {
+		if t.IsDefault {
+			defaultThemeName = t.Name
+			*selectedID = t.ID
+			break
+		}
+	}
+
+	if defaultThemeName != "" {
+		options = append(options, huh.NewOption("Use default ("+defaultThemeName+")", *selectedID))
+	}
+
+	for _, t := range resp.Themes {
+		if t.IsDefault && defaultThemeName != "" {
+			continue // Already added as "Use default" option
+		}
+
+		var baseSwatch, accentSwatch string
+
+		if t.DisplayColors != nil {
+			baseSwatch = renderColorBlock(t.DisplayColors.BaseColorHex)
+			accentSwatch = renderColorBlock(t.DisplayColors.AccentColorHex)
+		} else {
+			baseSwatch = "█"
+			accentSwatch = "█"
+		}
+
+		label := t.Name
+		label += "  " + dimText("Base") + " " + baseSwatch
+		label += "  " + dimText("Accent") + " " + accentSwatch
+		label += "  " + dimText("Font:") + " " + t.Config.Font
+		label += "  " + dimText("Radius:") + " " + t.Config.Radius
+
+		if t.Config.Elevation != "" {
+			label += "  " + dimText("Elevation:") + " " + t.Config.Elevation
+		}
+
+		options = append(options, huh.NewOption(label, t.ID))
+	}
+
+	field := huh.NewSelect[string]().
+		Title("Theme").
+		Description("Select a theme for your application").
+		Options(options...).
+		Height(5).
+		Value(selectedID)
+
+	return field, nil
 }

--- a/cmd/app/start.go
+++ b/cmd/app/start.go
@@ -32,6 +32,11 @@ func runStart(cobraCmd *cobra.Command) error {
 		cobraCmd.Printf("Warning: Failed to generate .mcp.json: %v\n", err)
 	}
 
+	// Generate theme files (check for changes)
+	if err := handleThemeSync(cobraCmd); err != nil {
+		cobraCmd.Printf("Warning: Failed to sync theme files: %v\n", err)
+	}
+
 	// Run start in current directory
 	return RunStartInDir(cobraCmd, "")
 }


### PR DESCRIPTION
- On the app setup ask about theme to select
- On the app startup suggest to upgrade to the latest theme version (if exists)
- Add local skill with lightweight set of theme usage instructions

<img width="300" height="143" alt="2" src="https://github.com/user-attachments/assets/3b01519c-d82d-4bad-9634-6d444b66368c" />
<img width="763" height="410" alt="1" src="https://github.com/user-attachments/assets/7bd4cdc7-9fe7-4441-bd1b-952fa7225a5d" />
