### PR TITLE
feat: add transferable ai-coder skills to CLI plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "major",
       "source": "./plugins/major",
       "description": "Use the Major platform agentically via Claude Code",
-      "version": "1.0.1"
+      "version": "1.0.2"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
 cli
-major
+/major
 major-dev

--- a/plugins/major/skills/authn/SKILL.md
+++ b/plugins/major/skills/authn/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: using-authn
+description: Implements AuthN (identity) operations. Use whenever building anything that requires AuthN
+---
+
+To get a user's identity, use @lib/auth.ts. If the user is logged in, the endpoint will return the user's email, userId, and name.
+
+All AuthZ should be handled by the user's application. This function should be purely used for identifying the current user that is logged in. There should be no other way of determining the user's identity.

--- a/plugins/major/skills/crons/SKILL.md
+++ b/plugins/major/skills/crons/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: using-crons
+description: Use when the user needs to run something on a cadence or do anything that interacts with crons. Creates, modifies and deletes cron jobs that run on a cadence.
+---
+
+# Cron Jobs
+
+Scheduled jobs are configured via a `cron.json` file at the project root and handled by route endpoints in the application.
+
+## cron.json
+
+Create `cron.json` at the project root:
+
+```json
+{
+	"version": "1",
+	"crons": [
+		{
+			"name": "daily-cleanup",
+			"description": "Removes expired sessions",
+			"url": "/api/crons/cleanup",
+			"schedule": "0 2 * * *"
+		}
+	]
+}
+```
+
+Fields:
+
+- `name` — unique identifier for the job
+- `description` — human-readable explanation (used for documentation)
+- `url` — the route path the scheduler will POST to
+- `schedule` — 5-field cron expression (see below)
+
+## Schedule Format
+
+Use a 5-field cron expression. Do **not** include a seconds field.
+
+```
+┌─ minute (0–59)
+│  ┌─ hour (0–23)
+│  │  ┌─ day of month (1–31)
+│  │  │  ┌─ month (1–12)
+│  │  │  │  ┌─ day of week (0–7, 0 and 7 = Sunday)
+│  │  │  │  │
+*  *  *  *  *
+```
+
+Common schedules:
+
+| Schedule               | Expression    |
+| ---------------------- | ------------- |
+| Every minute           | `* * * * *`   |
+| Every 5 minutes        | `*/5 * * * *` |
+| Every hour             | `0 * * * *`   |
+| Every day at 2 AM      | `0 2 * * *`   |
+| Every Monday 9 AM      | `0 9 * * 1`   |
+| 1st of month, midnight | `0 0 1 * *`   |
+
+## Notes
+
+- You should tell the user after you've build the scheduled job that they need to deploy for the cron to take affect
+- The user can see a list of all crons they have on the left hand side bar

--- a/plugins/major/skills/data-table/SKILL.md
+++ b/plugins/major/skills/data-table/SKILL.md
@@ -1,0 +1,1252 @@
+---
+name: using-frontend-data-table
+description: Creates frontend table views. Use whenever creating any type of table UI on the frontend. Use when doing ANYHTHING that involves tables (using tables to display data).
+---
+
+# DataTable
+
+A composable, full-featured DataTable built on TanStack Table v8. Installed via the shadcn registry — code lives locally in the project.
+
+## Installation
+
+Install via the shadcn registry:
+
+```bash
+npx shadcn@latest add https://cdn.major.build/shadcn/data-table.json
+```
+
+This copies the data table source code into `components/data-table/` in the project. All imports use the project's path alias (typically `@/components/data-table`).
+
+## Is a Table the Right UI?
+
+Before building a table, evaluate whether the data actually fits a tabular layout. Check these signals:
+
+**Use a table when:**
+
+- Each record has 3+ distinct fields (e.g. name, email, role, status, created date)
+- Users need to compare values across rows (scanning columns)
+- The data benefits from sorting, filtering, or pagination
+- The page is operational — users manage, edit, or act on records
+
+**Don't use a table when:**
+
+- Items are media-heavy (images, thumbnails, previews are the primary content)
+- Each item has only 1–2 fields — a simple list or card grid is better
+- The layout is a feed, timeline, or activity log with variable-length content
+- Visual presentation matters more than data density (e.g. product showcase, profile cards)
+
+**When ambiguous** (e.g. "show me a list of projects" — could be cards or a table), use `AskUserQuestion` to ask the user whether they want a data table or a card/list layout. Briefly explain the trade-off: tables are better for dense, scannable data with actions; cards are better for visual, media-rich items.
+
+If a table is not the right fit, do not use this skill — build the appropriate UI directly instead.
+
+## Feature Selection
+
+Every table includes these features by default — do not ask the user about them:
+
+- **Global search** — Search across all columns with debounced input
+- **Column filters** — Dynamic per-column filters (select, text, number, date, boolean)
+- **Column sorting** — Click column headers to sort
+
+Before implementing a table, use the `AskUserQuestion` tool to ask the user which additional features they need.
+
+First, ask a single-select question for the pagination strategy:
+
+- **Offset pagination** — Page navigation with page size selector
+- **Infinite scroll** — Load more rows automatically as the user scrolls
+- **None** — No pagination (all data rendered at once)
+
+Then, ask a multi-select question for optional features:
+
+- **Column visibility** — Toggle which columns are visible
+- **Column reordering** — Drag-and-drop to rearrange columns
+- **Column resizing** — Drag column borders to resize
+- **Row actions** — Three-dot dropdown menu per row (edit, delete, etc.)
+- **Row selection** — Checkbox selection with bulk action bar
+- **Expandable rows** — Click to expand rows with detail content
+- **Data export** — Export current page or all data as CSV
+- **Sticky header** — Pin header while scrolling the table body
+
+Only compose the features the user selects. Do not add features they did not ask for. If the user rejects or dismisses the question, infer the most reasonable set of features from context (the data source, dataset size, and what the user described) and proceed without asking again.
+
+**Virtualization:** Do not ask the user about virtualization. Enable it automatically when the page size exceeds 200 rows or when infinite scroll is selected, since those scenarios render enough rows to benefit from it.
+
+## Version Check
+
+When the user asks to modify, update, or add features to an existing table, check whether the installed version is current before making changes:
+
+1. Read the local `DATA_TABLE_VERSION` constant from the project's `data-table/constants.ts`.
+2. Fetch `https://cdn.major.build/shadcn/data-table.json` and read the `version` field from the JSON.
+3. If the remote version is newer than the local version, inform the user and suggest updating:
+   - Run `npx shadcn@latest add https://cdn.major.build/shadcn/data-table.json` to pull the latest code.
+   - If the user confirms the update, verify that any existing backend endpoints (API routes, resource queries) still work correctly with the updated table code. Fix any breaking changes.
+   - Review the changelog between versions. If the new version introduced features that are relevant to the user's table, suggest incorporating them using `AskUserQuestion`. Only suggest features that make sense for their use case — do not push everything.
+4. If versions match, proceed directly with the requested changes.
+
+## Quick Start — Auto Mode
+
+Pass `onLoadRows` and the table manages ALL internal state — data, loading, sorting, filtering, pagination.
+
+```tsx
+import { DataTable, DataTableContent, DataTablePagination, buildRequestSearchParams } from "@/components/data-table";
+import type { ColumnDef, DataTableResponse } from "@/components/data-table";
+
+interface User {
+	id: string;
+	name: string;
+	email: string;
+}
+
+const columns: ColumnDef<User, unknown>[] = [
+	{ accessorKey: "name", header: "Name" },
+	{ accessorKey: "email", header: "Email" },
+];
+
+async function loadUsers(params) {
+	const res = await fetch(`/api/users?${buildRequestSearchParams(params)}`);
+	if (!res.ok) {
+		return { success: false, error: { code: String(res.status), message: "Failed to fetch" } };
+	}
+	return res.json(); // Must return DataTableResponse<User>
+}
+
+export default function UsersPage() {
+	return (
+		<DataTable onLoadRows={loadUsers} columns={columns}>
+			<DataTableContent />
+			<DataTablePagination />
+		</DataTable>
+	);
+}
+```
+
+## Architecture
+
+**Compound components via context.** The root `<DataTable>` creates a TanStack Table instance and provides it through React Context. Sub-components consume the context — compose only the pieces you need.
+
+**Two modes:**
+
+1. **Auto mode** — Pass `onLoadRows`. The table calls it with `DataTableRequestParams` whenever sorting, filtering, or pagination changes. All data fetching and state management is handled internally.
+2. **Static mode** — Pass `data` directly. Sorting, filtering, and pagination happen client-side by default. Optionally pass controlled state props (`sorting` + `onSortingChange`, etc.) for server-controlled static mode.
+
+**Composable.** Every sub-component is optional. Mix and match `<DataTablePagination>`, `<DataTableInfiniteScroll>`, `<DataTableToolbar>`, `<DataTableExport>`, etc.
+
+---
+
+## Composition Guide
+
+### Minimal table — just content
+
+```tsx
+<DataTable columns={columns} data={rows}>
+	<DataTableContent />
+</DataTable>
+```
+
+### With pagination
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={columns}>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>
+```
+
+### With infinite scroll
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={columns}>
+	<DataTableContent />
+	<DataTableInfiniteScroll />
+</DataTable>
+```
+
+### With toolbar (search + filters + column toggle + export)
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={columns}>
+	<DataTableToolbar>
+		<DataTableSearch placeholder="Search users..." />
+		<DataTableFilters filters={filterDefinitions} />
+		<div className="flex-1" />
+		<DataTableExport
+			formatRows={(rows) => rowsToCsv(rows)}
+			onExportAll={async () => downloadFile("/api/users/export")}
+		/>
+		<DataTableColumnToggle />
+	</DataTableToolbar>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>
+```
+
+### With row selection + bulk actions
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={[createSelectColumn<User>(), ...baseColumns]} getRowId={(u) => u.id}>
+	<DataTableRowSelection<User>>
+		{(rows) => <button onClick={() => handleBulkDelete(getSelectedRows(rows))}>Delete ({rows.length})</button>}
+	</DataTableRowSelection>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>
+```
+
+### With row actions
+
+```tsx
+const columns = [
+	...baseColumns,
+	createActionsColumn<User>((row) => [
+		{ label: "Edit", onSelect: (r) => router.push(`/users/${r.id}/edit`) },
+		{ label: "View details", onSelect: (r) => router.push(`/users/${r.id}`) },
+		{ type: "separator" },
+		{
+			label: "Delete",
+			variant: "destructive",
+			onSelect: async (r, { removeRow }) => {
+				await handleDelete(r.id);
+				removeRow(r.id);
+			},
+		},
+	]),
+];
+
+<DataTable onLoadRows={loadRows} columns={columns}>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>;
+```
+
+### With expandable rows
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={[createExpandColumn<User>(), ...baseColumns]}>
+	<DataTableContent renderExpandedRow={(row) => <UserDetail user={row.original} />} />
+	<DataTablePagination />
+</DataTable>
+```
+
+### With virtualization (large datasets)
+
+Virtualization renders only visible rows. Requires `maxHeight` to define the scroll viewport. Built-in infinite scroll triggers `loadNextPage` automatically when nearing the bottom.
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={columns}>
+	<DataTableContent virtualized maxHeight={600} estimateRowHeight={48} overscan={10} />
+</DataTable>
+```
+
+### With sticky header
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={columns}>
+	<DataTableContent stickyHeader maxHeight={500} />
+	<DataTablePagination />
+</DataTable>
+```
+
+### Kitchen sink
+
+```tsx
+const columns = [
+	createSelectColumn<User>(),
+	createExpandColumn<User>(),
+	...baseColumns,
+	createActionsColumn<User>((row) => [
+		{ label: "Edit", onSelect: (r) => router.push(`/users/${r.id}/edit`) },
+		{ type: "separator" },
+		{
+			label: "Delete",
+			variant: "destructive",
+			onSelect: async (r, { removeRow }) => {
+				await api.deleteUser(r.id);
+				removeRow(r.id);
+			},
+		},
+	]),
+];
+
+<DataTable
+	onLoadRows={loadRows}
+	columns={columns}
+	getRowId={(u) => u.id}
+	pageSize={50}
+	enableColumnReordering
+	enableColumnResizing
+	onError={(err) => toast.error(err.message)}
+>
+	<DataTableToolbar>
+		<DataTableSearch placeholder="Search..." />
+		<DataTableFilters filters={filterDefinitions} />
+		<div className="flex-1" />
+		<DataTableExport
+			formatRows={(rows) => rowsToCsv(rows)}
+			onExportAll={async () => downloadFile("/api/users/export")}
+		/>
+		<DataTableColumnToggle />
+	</DataTableToolbar>
+	<DataTableRowSelection<User>>
+		{(rows) => <button onClick={() => handleDelete(rows)}>Delete ({rows.length})</button>}
+	</DataTableRowSelection>
+	<DataTableContent renderExpandedRow={(row) => <UserDetail user={row.original} />} stickyHeader maxHeight={600} />
+	<DataTablePagination />
+</DataTable>;
+```
+
+**Note:** The actions column is automatically pinned to the right edge with a sticky position. When the table overflows horizontally, the actions column stays visible with a subtle left shadow. It is excluded from column drag-and-drop reordering.
+
+### Static mode — client-side data
+
+All sorting, filtering, and pagination happens in the browser. No server calls.
+
+```tsx
+<DataTable columns={columns} data={allRows}>
+	<DataTableToolbar>
+		<DataTableSearch />
+		<DataTableFilters filters={filterDefinitions} />
+	</DataTableToolbar>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>
+```
+
+### Static mode with server-controlled state
+
+Pass `data` but also provide controlled state props. The table switches to manual mode when it sees `sorting + onSortingChange`, `pagination + onPaginationChange`, etc.
+
+```tsx
+const [sorting, setSorting] = useState<SortingState>([]);
+const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 });
+
+// Fetch data whenever sorting/pagination changes
+const { data, totalCount, isLoading } = useFetchUsers({ sorting, pagination });
+
+<DataTable
+	columns={columns}
+	data={data}
+	isLoading={isLoading}
+	sorting={sorting}
+	onSortingChange={setSorting}
+	pagination={pagination}
+	onPaginationChange={setPagination}
+	rowCount={totalCount}
+>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>;
+```
+
+---
+
+## Component Reference
+
+### `<DataTable>` — Root
+
+Creates the TanStack Table instance and provides context. All sub-components must be children.
+
+**Auto mode props** (pass `onLoadRows`):
+
+| Prop          | Type                                                 | Default | Description                                                              |
+| ------------- | ---------------------------------------------------- | ------- | ------------------------------------------------------------------------ |
+| `onLoadRows`  | `DataTableLoadRowsFn<TData>`                         | —       | Promise-returning load function — enables auto mode                      |
+| `initialData` | `PaginatedResponse<TData>`                           | —       | Pre-loaded first page for SSR — renders immediately, skips initial fetch |
+| `onError`     | `(error: { code: string; message: string }) => void` | —       | Called when `onLoadRows` returns an error response                       |
+
+**Static mode props** (pass `data`):
+
+| Prop                                      | Type                                | Default | Description                                 |
+| ----------------------------------------- | ----------------------------------- | ------- | ------------------------------------------- |
+| `data`                                    | `TData[]`                           | —       | Row data to display                         |
+| `isLoading`                               | `boolean`                           | `false` | Show loading state                          |
+| `sorting` / `onSortingChange`             | `SortingState` / `OnChangeFn`       | —       | Controlled sorting (implies manual mode)    |
+| `columnFilters` / `onColumnFiltersChange` | `ColumnFiltersState` / `OnChangeFn` | —       | Controlled filtering (implies manual mode)  |
+| `globalFilter` / `onGlobalFilterChange`   | `string` / `OnChangeFn`             | —       | Controlled search                           |
+| `pagination` / `onPaginationChange`       | `PaginationState` / `OnChangeFn`    | —       | Controlled pagination (implies manual mode) |
+| `rowCount`                                | `number`                            | —       | Total row count for server-side pagination  |
+
+**Shared props** (both modes):
+
+| Prop                                            | Type                               | Default | Description                       |
+| ----------------------------------------------- | ---------------------------------- | ------- | --------------------------------- |
+| `columns`                                       | `ColumnDef<TData>[]`               | —       | Column definitions (required)     |
+| `getRowId`                                      | `(row: TData) => string`           | —       | Custom row ID extractor           |
+| `pageSize`                                      | `number`                           | `50`    | Initial page size                 |
+| `rowSelection` / `onRowSelectionChange`         | `RowSelectionState` / `OnChangeFn` | —       | Controlled row selection          |
+| `expanded` / `onExpandedChange`                 | `ExpandedState` / `OnChangeFn`     | —       | Controlled expanded rows          |
+| `columnVisibility` / `onColumnVisibilityChange` | `VisibilityState` / `OnChangeFn`   | —       | Controlled column visibility      |
+| `enableMultiSort`                               | `boolean`                          | `false` | Allow sorting by multiple columns |
+| `enableColumnReordering`                        | `boolean`                          | `false` | Drag-and-drop column reordering   |
+| `enableColumnResizing`                          | `boolean`                          | `false` | Drag column borders to resize     |
+
+### `<DataTableContent>` — Main table
+
+Renders the full table: header, body, loading skeleton, empty state, and error state with retry.
+
+| Prop                | Type                             | Default                 | Description                                                                                                                                       |
+| ------------------- | -------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `renderExpandedRow` | `(row: Row<TData>) => ReactNode` | —                       | Content to show when a row is expanded                                                                                                            |
+| `onRowClick`        | `(row: Row<TData>) => void`      | —                       | Click handler for rows                                                                                                                            |
+| `emptyTitle`        | `string`                         | `"No results"`          | Title for empty state                                                                                                                             |
+| `emptyDescription`  | `string`                         | `"No data to display."` | Description for empty state                                                                                                                       |
+| `emptyContent`      | `ReactNode`                      | —                       | Custom empty state content                                                                                                                        |
+| `stickyHeader`      | `boolean`                        | `false`                 | Pin the header while scrolling. Pair with `maxHeight`.                                                                                            |
+| `maxHeight`         | `number \| string`               | —                       | Constrains the scroll area height. Required for `stickyHeader` and `virtualized`.                                                                 |
+| `virtualized`       | `boolean`                        | `false`                 | Enable row virtualization. Renders only visible rows + overscan buffer. Built-in infinite scroll triggers `loadNextPage` when nearing the bottom. |
+| `estimateRowHeight` | `number`                         | `48`                    | Estimated row height in px for the virtualizer                                                                                                    |
+| `overscan`          | `number`                         | `5`                     | Number of rows to render outside the visible area                                                                                                 |
+
+### `<DataTablePagination>` — Offset pagination
+
+| Prop              | Type       | Default             | Description                       |
+| ----------------- | ---------- | ------------------- | --------------------------------- |
+| `pageSizeOptions` | `number[]` | `[10, 20, 50, 100]` | Page size choices                 |
+| `sticky`          | `boolean`  | `false`             | Pin to bottom of scroll container |
+
+### `<DataTableInfiniteScroll>` — Infinite scroll
+
+In auto mode, no props needed — reads `loadNextPage` and `hasMore` from context. Uses IntersectionObserver on a sentinel element.
+
+| Prop         | Type                          | Description                           |
+| ------------ | ----------------------------- | ------------------------------------- |
+| `onLoadMore` | `() => void \| Promise<void>` | Manual mode: function to load more    |
+| `hasMore`    | `boolean`                     | Manual mode: whether more data exists |
+
+### `<DataTableToolbar>` — Toolbar container
+
+Simple flex container for composing toolbar items. Props: `className`, `children`.
+
+### `<DataTableSearch>` — Global search
+
+| Prop          | Type     | Default       | Description      |
+| ------------- | -------- | ------------- | ---------------- |
+| `placeholder` | `string` | `"Search..."` | Placeholder text |
+| `debounceMs`  | `number` | `300`         | Debounce delay   |
+
+### `<DataTableFilters>` — Dynamic column filters
+
+Renders a "Filters" button that opens a dropdown where users dynamically add/remove column filters. Each filter type has a purpose-built inline input.
+
+| Prop      | Type                          | Description                    |
+| --------- | ----------------------------- | ------------------------------ |
+| `filters` | `DataTableFilterDefinition[]` | Filter definitions (see below) |
+
+**Filter definition types:**
+
+```tsx
+import type { DataTableFilterDefinition } from "@/components/data-table";
+
+const filters: DataTableFilterDefinition[] = [
+	{
+		columnId: "role",
+		title: "Role",
+		type: "select",
+		options: [
+			{ label: "Admin", value: "admin" },
+			{ label: "Editor", value: "editor" },
+		],
+	},
+	{ columnId: "name", title: "Name", type: "text" },
+	{ columnId: "score", title: "Score", type: "number" },
+	{ columnId: "createdAt", title: "Created", type: "date" },
+	{ columnId: "verified", title: "Verified", type: "boolean" },
+];
+```
+
+**Filter types, operators, and query param encoding:**
+
+| Type      | Operators                                           | Column filter value shape             | URL params                                                                                             |
+| --------- | --------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `select`  | (multi-select, no operator)                         | `string[]`                            | `role=admin,editor`                                                                                    |
+| `text`    | `contains`, `eq`, `starts_with`, `ends_with`, `neq` | `{ op, value }`                       | `name=john&name_op=contains`                                                                           |
+| `number`  | `eq`, `lt`, `gt`, `neq`, `range`                    | `{ op, value }` or `{ op, min, max }` | `score=50&score_op=gt` or `score_op=range&score_min=10&score_max=100`                                  |
+| `date`    | `eq`, `before`, `after`, `neq`, `range`             | `{ op, value }` or `{ op, from, to }` | `createdAt=2024-06-01&createdAt_op=before` or `createdAt_op=range&createdAt_from=...&createdAt_to=...` |
+| `boolean` | (toggle, no operator)                               | `boolean`                             | `verified=true`                                                                                        |
+
+### `<DataTableFacetedFilter>` — Standalone column filter
+
+For cases where you need a standalone filter button for one column (outside the dynamic filter system).
+
+| Prop       | Type                                 | Description       |
+| ---------- | ------------------------------------ | ----------------- |
+| `columnId` | `string`                             | Column to filter  |
+| `title`    | `string`                             | Button label      |
+| `options`  | `{ label: string; value: string }[]` | Options to select |
+
+### `<DataTableColumnToggle>` — Column visibility dropdown
+
+| Prop    | Type     | Default     | Description  |
+| ------- | -------- | ----------- | ------------ |
+| `label` | `string` | `"Columns"` | Button label |
+
+### `<DataTableExport>` — Export button
+
+Supports current-page export (client-side) and all-data export (server-side). When `onExportAll` is provided, renders a dropdown with "Current page" and "All data" options.
+
+| Prop          | Type                          | Default        | Description                                                         |
+| ------------- | ----------------------------- | -------------- | ------------------------------------------------------------------- |
+| `formatRows`  | `(rows: TData[]) => string`   | —              | Serializes current-page row data to a file string (e.g. CSV)        |
+| `filename`    | `string`                      | `"export.csv"` | Filename for current-page export                                    |
+| `onExportAll` | `() => void \| Promise<void>` | —              | Calls a server endpoint for full export. Use with `downloadFile()`. |
+| `label`       | `string`                      | `"Export"`     | Button label                                                        |
+
+### `<DataTableRowSelection>` — Bulk action bar
+
+Renders only when at least one row is selected.
+
+| Prop       | Type                                        | Description                         |
+| ---------- | ------------------------------------------- | ----------------------------------- |
+| `children` | `(selectedRows: Row<TData>[]) => ReactNode` | Render prop receiving selected rows |
+
+### `<DataTableSkeleton>` — Loading skeleton
+
+| Prop          | Type     | Default | Description                |
+| ------------- | -------- | ------- | -------------------------- |
+| `columnCount` | `number` | `4`     | Number of skeleton columns |
+| `rowCount`    | `number` | `5`     | Number of skeleton rows    |
+
+### `<DataTableEmpty>` — Empty state
+
+| Prop          | Type        | Default                 | Description             |
+| ------------- | ----------- | ----------------------- | ----------------------- |
+| `title`       | `string`    | `"No results"`          | Empty state title       |
+| `description` | `string`    | `"No data to display."` | Empty state description |
+| `children`    | `ReactNode` | —                       | Custom content          |
+
+---
+
+## Column Reordering & Resizing
+
+### Column reordering
+
+Enable with `enableColumnReordering` on `<DataTable>`. Users drag columns by a grip handle to rearrange them. The new order is applied via TanStack Table's `setColumnOrder`.
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={columns} enableColumnReordering>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>
+```
+
+**Non-draggable columns:** The select (`_select`), expand (`_expand`), and actions (`_actions`) columns are excluded from reordering. They stay pinned in their positions.
+
+**Controlled column order:** To persist or control the order externally, use TanStack Table's `columnOrder` state:
+
+```tsx
+const [columnOrder, setColumnOrder] = useState<string[]>([]);
+
+<DataTable
+	onLoadRows={loadRows}
+	columns={columns}
+	enableColumnReordering
+	columnOrder={columnOrder}
+	onColumnOrderChange={setColumnOrder}
+>
+	<DataTableContent />
+</DataTable>;
+```
+
+### Column resizing
+
+Enable with `enableColumnResizing` on `<DataTable>`. Users drag the right border of column headers to resize. A blue indicator appears on hover/drag. Body cells also have resize handles for convenience.
+
+```tsx
+<DataTable onLoadRows={loadRows} columns={columns} enableColumnResizing>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>
+```
+
+**How it works:** On first render with data, the table measures actual DOM column widths and pre-populates TanStack's `columnSizing` state. This prevents a layout jump when the user starts resizing. Once measured, the table switches to `table-layout: fixed` with explicit widths.
+
+**Opting out per column:** Set `enableResizing: false` on individual column definitions to prevent them from being resized. The select, expand, and actions utility columns disable resizing by default.
+
+---
+
+## Column Helpers & Hooks
+
+### Column factories
+
+```tsx
+import { createSelectColumn, createExpandColumn, createActionsColumn } from "@/components/data-table";
+import type { ActionDefinition } from "@/components/data-table";
+
+const columns = [
+	createSelectColumn<User>(), // Checkbox column
+	createExpandColumn<User>(), // Expand toggle column
+	{ accessorKey: "name", header: "Name" },
+	createActionsColumn<User>((row) => [
+		{ label: "Edit", onSelect: (r) => router.push(`/users/${r.id}/edit`) },
+		{ label: "Copy ID", onSelect: (r) => navigator.clipboard.writeText(r.id) },
+		{ type: "separator" },
+		{
+			label: "Delete",
+			variant: "destructive",
+			onSelect: async (r, { removeRow }) => {
+				await api.deleteUser(r.id);
+				removeRow(r.id);
+			},
+		},
+	]),
+];
+```
+
+### `createActionsColumn` — Row actions dropdown
+
+Creates a three-dot (`⋮`) dropdown menu column. Place as the last column. The `getActions` callback receives the row data and returns action definitions.
+
+**Action item fields:**
+
+| Field      | Type                                                     | Default     | Description                                                                                |
+| ---------- | -------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------ |
+| `label`    | `string`                                                 | —           | Menu item text                                                                             |
+| `onSelect` | `(row: TData, actions: DataTableActions<TData>) => void` | —           | Callback when item is clicked. Second arg provides `reloadPage`, `updateRow`, `removeRow`. |
+| `variant`  | `"default" \| "destructive"`                             | `"default"` | Visual style (red for danger)                                                              |
+| `disabled` | `boolean`                                                | `false`     | Disable the item                                                                           |
+| `icon`     | `ReactNode`                                              | —           | Icon rendered before the label                                                             |
+
+Use `{ type: "separator" }` between items to add a visual divider.
+
+### Hooks
+
+```tsx
+import { useDataTable, useDataTableState, useDataTableActions } from "@/components/data-table";
+
+// TanStack Table instance — access rows, columns, state, handlers
+const table = useDataTable<User>();
+
+// DataTable state context — loading, error, infinite scroll, feature flags
+const { isLoading, hasMore, loadNextPage, error, retry, enableColumnReordering, enableColumnResizing } =
+	useDataTableState();
+
+// Data mutation actions — for optimistic updates from row actions
+const { reloadPage, updateRow, removeRow } = useDataTableActions<User>();
+```
+
+### `useDataTableActions<TData>()` — Row-level data mutations
+
+Returns typed helpers for optimistic row updates. **Only works in auto mode** (when `onLoadRows` is provided). Requires `getRowId` on `<DataTable>`.
+
+| Method       | Signature                                                 | Description                                                                 |
+| ------------ | --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `reloadPage` | `() => void`                                              | Re-fetches the current page from the server with current params             |
+| `updateRow`  | `(rowId: string, updater: (row: TData) => TData) => void` | Optimistically replaces a row in the current data by ID                     |
+| `removeRow`  | `(rowId: string) => void`                                 | Optimistically removes a row from the current data and decrements the count |
+
+**Usage with row actions:**
+
+The `onSelect` callback in `createActionsColumn` receives the table actions as a second argument, giving direct access to `reloadPage`, `updateRow`, and `removeRow` without any bridge components or refs:
+
+```tsx
+import { createActionsColumn, type ActionDefinition } from "@/components/data-table";
+
+const getRowActions = (row: User): ActionDefinition<User>[] => [
+	{
+		label: "Toggle status",
+		onSelect: async (r, { updateRow }) => {
+			const updated = await api.toggleUserStatus(r.id);
+			updateRow(r.id, () => updated);
+		},
+	},
+	{ type: "separator" },
+	{
+		label: "Delete",
+		variant: "destructive",
+		onSelect: async (r, { removeRow }) => {
+			await api.deleteUser(r.id);
+			removeRow(r.id);
+		},
+	},
+];
+
+const columns = [...baseColumns, createActionsColumn<User>(getRowActions)];
+
+<DataTable onLoadRows={loadUsers} columns={columns} getRowId={(u) => u.id}>
+	<DataTableContent />
+	<DataTablePagination />
+</DataTable>;
+```
+
+### Utility functions
+
+```tsx
+import { getSelectedRows, downloadFile, buildRequestSearchParams } from "@/components/data-table";
+
+// Extract original data from selected Row objects
+const users: User[] = getSelectedRows(table.getFilteredSelectedRowModel().rows);
+
+// Trigger a browser file download from a URL
+await downloadFile("/api/users/export?format=csv", "users.csv");
+// Resolves filename from: explicit argument → Content-Disposition header → "export"
+
+// Convert DataTableRequestParams to URLSearchParams
+const searchParams = buildRequestSearchParams(params);
+```
+
+---
+
+## Response Contract & Query Params
+
+### `DataTableResponse<T>` — what `onLoadRows` must return
+
+```typescript
+// Success
+{
+  success: true,
+  items: T[],
+  page: number,        // 0-based page index
+  totalPages: number,
+  totalCount: number,
+}
+
+// Error — table keeps existing data, shows error state, calls onError callback
+{
+  success: false,
+  error: { code: string, message: string },
+}
+```
+
+### `DataTableRequestParams` — what `onLoadRows` receives
+
+```typescript
+{
+  page: number,                   // 0-based page index
+  pageSize: number,
+  sorting: SortingState,          // [{ id: "columnId", desc: boolean }]
+  columnFilters: ColumnFiltersState,
+  globalFilter: string,
+}
+```
+
+### Full query param table
+
+`buildRequestSearchParams()` converts `DataTableRequestParams` to `URLSearchParams`:
+
+| Param             | Type                | Example                     | Description                           |
+| ----------------- | ------------------- | --------------------------- | ------------------------------------- |
+| `page`            | `number`            | `0`                         | 0-based page index                    |
+| `pageSize`        | `number`            | `50`                        | Items per page                        |
+| `sortBy`          | `string`            | `name`                      | Column accessor to sort by            |
+| `sortDesc`        | `"true" \| "false"` | `false`                     | Sort direction                        |
+| `search`          | `string`            | `john`                      | Global search query                   |
+| `{columnId}`      | `string`            | `role=admin,editor`         | Select filter: comma-separated values |
+| `{columnId}`      | `"true" \| "false"` | `verified=true`             | Boolean filter                        |
+| `{columnId}`      | `string \| number`  | `name=john`                 | Text/number/date single-value filter  |
+| `{columnId}_op`   | `string`            | `name_op=contains`          | Filter operator                       |
+| `{columnId}_min`  | `number`            | `score_min=10`              | Number range: minimum                 |
+| `{columnId}_max`  | `number`            | `score_max=100`             | Number range: maximum                 |
+| `{columnId}_from` | `string`            | `createdAt_from=2024-01-01` | Date range: start                     |
+| `{columnId}_to`   | `string`            | `createdAt_to=2024-12-31`   | Date range: end                       |
+
+---
+
+## Building Server Endpoints
+
+### Data Source Capability Assessment
+
+Before wiring up a table, assess what the data source can efficiently do:
+
+**Tier 1 — Full features** (indexed PostgreSQL via resource client):
+
+- Server-side pagination, sorting, filtering, search, export all efficient
+- Enable all table features: pagination, search, filters, column sorting, export
+- Requires: proper indexes on sort/filter/search columns
+
+**Tier 2 — Limited features** (unindexed Postgres, DynamoDB, external APIs with pagination):
+
+- Some operations are expensive (full table scans for search, sorts on non-key columns)
+- Enable: pagination and sorting on indexed/key columns only
+- Warn user: "Search and filtering on [column] requires a full table scan. Consider adding an index, or use a simpler table without these features."
+- DynamoDB: only sort within partition key, filter on GSI attributes
+
+**Tier 3 — Client-side only** (Google Sheets, small datasets, APIs without pagination):
+
+- Fetch all data, use static mode with client-side sorting/filtering
+- Use `<DataTable data={allRows}>` instead of `onLoadRows`
+- No server-side search/filter overhead
+- Warn if dataset > ~1000 rows: "All data is loaded into the browser at once. Performance may degrade with large datasets."
+
+The AI coder should:
+
+1. Check resource type and schema/indexes before choosing features
+2. Match table capabilities to what the data source can efficiently support
+3. Proactively warn user about performance trade-offs when requested features don't match source capabilities
+4. Suggest index creation (for managed Postgres) or feature reduction when appropriate
+
+### Data Access
+
+Data is accessed through resource clients (`@major-tech/resource-client`), NOT direct database connections. The resource client handles authentication, connection pooling, and multi-tenant isolation.
+
+For PostgreSQL resources, the resource client executes raw SQL and returns typed results. The patterns below show the SQL to generate — pass them through the resource client's query method.
+
+### Next.js Route Handler Pattern
+
+All generated apps are Next.js. Server endpoints go in `app/api/.../route.ts`:
+
+```typescript
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+// Zod schema for validating query params
+const querySchema = z.object({
+	page: z.coerce.number().int().min(0).default(0),
+	pageSize: z.coerce.number().int().min(1).max(200).default(50),
+	sortBy: z.string().optional(),
+	sortDesc: z.enum(["true", "false"]).optional(),
+	search: z.string().optional(),
+});
+
+// Whitelist of sortable columns — ALWAYS validate against this
+const SORTABLE_COLUMNS = ["name", "email", "created_at", "score"] as const;
+
+export async function GET(request: NextRequest) {
+	const params = request.nextUrl.searchParams;
+
+	try {
+		const query = querySchema.parse(Object.fromEntries(params));
+
+		// 1. Build WHERE clause from filters
+		const { whereClause, values } = buildWhereClause(params);
+
+		// 2. Validate sort column against whitelist
+		const sortColumn = SORTABLE_COLUMNS.includes(query.sortBy as any) ? query.sortBy : "created_at";
+		const sortDir = query.sortDesc === "true" ? "DESC" : "ASC";
+
+		// 3. Run count + data queries (can be parallel for better latency)
+		const offset = query.page * query.pageSize;
+
+		const [countResult, dataResult] = await Promise.all([
+			resourceClient.invoke(`SELECT COUNT(*) as count FROM users ${whereClause}`, values, "count-users"),
+			resourceClient.invoke(
+				`SELECT * FROM users ${whereClause} ORDER BY ${sortColumn} ${sortDir} LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
+				[...values, query.pageSize, offset],
+				"list-users",
+			),
+		]);
+
+		if (!countResult.ok || !dataResult.ok) {
+			throw new Error("Database query failed");
+		}
+
+		const totalCount = Number(countResult.result.rows[0].count);
+
+		return NextResponse.json({
+			success: true,
+			items: dataResult.result.rows,
+			page: query.page,
+			totalPages: Math.ceil(totalCount / query.pageSize),
+			totalCount,
+		});
+	} catch (error) {
+		console.error("Failed to fetch data:", error);
+		return NextResponse.json(
+			{ success: false, error: { code: "QUERY_FAILED", message: "Failed to fetch data" } },
+			{ status: 500 },
+		);
+	}
+}
+```
+
+### Building Postgres WHERE Clauses
+
+Translate the table's query params into parameterized SQL. Every filter type maps to specific SQL:
+
+```typescript
+interface WhereResult {
+	whereClause: string;
+	values: (string | number | boolean)[];
+}
+
+function buildWhereClause(params: URLSearchParams): WhereResult {
+	const conditions: string[] = [];
+	const values: (string | number | boolean)[] = [];
+	let paramIndex = 1;
+
+	// Global search — OR across multiple columns
+	const search = params.get("search");
+	if (search) {
+		const q = `%${search}%`;
+		conditions.push(`(name ILIKE $${paramIndex} OR email ILIKE $${paramIndex + 1})`);
+		values.push(q, q);
+		paramIndex += 2;
+	}
+
+	// Select filter: comma-separated values → IN clause
+	const role = params.get("role");
+	if (role) {
+		const roles = role.split(",");
+		const placeholders = roles.map((_, i) => `$${paramIndex + i}`).join(", ");
+		conditions.push(`role IN (${placeholders})`);
+		values.push(...roles);
+		paramIndex += roles.length;
+	}
+
+	// Text filter with operator
+	const name = params.get("name");
+	if (name) {
+		const op = params.get("name_op") ?? "contains";
+		switch (op) {
+			case "contains":
+				conditions.push(`name ILIKE $${paramIndex}`);
+				values.push(`%${name}%`);
+				break;
+			case "eq":
+				conditions.push(`LOWER(name) = LOWER($${paramIndex})`);
+				values.push(name);
+				break;
+			case "starts_with":
+				conditions.push(`name ILIKE $${paramIndex}`);
+				values.push(`${name}%`);
+				break;
+			case "ends_with":
+				conditions.push(`name ILIKE $${paramIndex}`);
+				values.push(`%${name}`);
+				break;
+			case "neq":
+				conditions.push(`LOWER(name) != LOWER($${paramIndex})`);
+				values.push(name);
+				break;
+		}
+		paramIndex++;
+	}
+
+	// Number filter with operator
+	const scoreOp = params.get("score_op") ?? "eq";
+	if (scoreOp === "range") {
+		const min = params.get("score_min");
+		const max = params.get("score_max");
+		if (min) {
+			conditions.push(`score >= $${paramIndex}`);
+			values.push(Number(min));
+			paramIndex++;
+		}
+		if (max) {
+			conditions.push(`score <= $${paramIndex}`);
+			values.push(Number(max));
+			paramIndex++;
+		}
+	} else {
+		const score = params.get("score");
+		if (score) {
+			const num = Number(score);
+			switch (scoreOp) {
+				case "eq":
+					conditions.push(`score = $${paramIndex}`);
+					break;
+				case "lt":
+					conditions.push(`score < $${paramIndex}`);
+					break;
+				case "gt":
+					conditions.push(`score > $${paramIndex}`);
+					break;
+				case "neq":
+					conditions.push(`score != $${paramIndex}`);
+					break;
+			}
+			values.push(num);
+			paramIndex++;
+		}
+	}
+
+	// Date filter with operator
+	const dateOp = params.get("created_at_op") ?? "eq";
+	if (dateOp === "range") {
+		const from = params.get("created_at_from");
+		const to = params.get("created_at_to");
+		if (from) {
+			conditions.push(`created_at >= $${paramIndex}`);
+			values.push(from);
+			paramIndex++;
+		}
+		if (to) {
+			conditions.push(`created_at <= $${paramIndex}`);
+			values.push(to);
+			paramIndex++;
+		}
+	} else {
+		const dateVal = params.get("created_at");
+		if (dateVal) {
+			switch (dateOp) {
+				case "eq":
+					conditions.push(`created_at::date = $${paramIndex}::date`);
+					break;
+				case "before":
+					conditions.push(`created_at < $${paramIndex}`);
+					break;
+				case "after":
+					conditions.push(`created_at > $${paramIndex}`);
+					break;
+				case "neq":
+					conditions.push(`created_at::date != $${paramIndex}::date`);
+					break;
+			}
+			values.push(dateVal);
+			paramIndex++;
+		}
+	}
+
+	// Boolean filter
+	const verified = params.get("verified");
+	if (verified) {
+		conditions.push(`verified = $${paramIndex}`);
+		values.push(verified === "true");
+		paramIndex++;
+	}
+
+	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+	return { whereClause, values };
+}
+```
+
+### Sorting with Whitelist Validation
+
+Never interpolate user input directly into ORDER BY. Always validate against a whitelist:
+
+```typescript
+const SORTABLE_COLUMNS: Record<string, string> = {
+	name: "name",
+	email: "email",
+	created_at: "created_at",
+	score: "score",
+};
+
+function buildOrderBy(params: URLSearchParams): string {
+	const sortBy = params.get("sortBy");
+	const sortDesc = params.get("sortDesc") === "true";
+
+	const column = sortBy && SORTABLE_COLUMNS[sortBy];
+	if (!column) {
+		return "ORDER BY created_at DESC"; // default sort
+	}
+
+	return `ORDER BY ${column} ${sortDesc ? "DESC" : "ASC"}`;
+}
+```
+
+### Indexing Best Practices
+
+Create indexes that match your table's common query patterns:
+
+```sql
+-- Composite index for common sort + filter combos
+CREATE INDEX idx_users_role_created ON users (role, created_at DESC);
+
+-- Partial index for filtered subsets (only rows matching condition are indexed)
+CREATE INDEX idx_users_active ON users (created_at DESC) WHERE status = 'active';
+
+-- Expression index for case-insensitive text search
+CREATE INDEX idx_users_name_lower ON users (LOWER(name));
+
+-- GIN index for trigram similarity (ILIKE '%term%' acceleration)
+-- Requires: CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX idx_users_name_trgm ON users USING GIN (name gin_trgm_ops);
+
+-- GIN index for full-text search
+CREATE INDEX idx_users_search ON users USING GIN (to_tsvector('english', name || ' ' || email));
+```
+
+**When to add indexes:**
+
+- Add indexes on columns that appear in WHERE, ORDER BY, or JOIN clauses
+- Composite indexes: put equality conditions first, range/sort columns last
+- Partial indexes: use when queries consistently filter to a subset (e.g. `WHERE deleted_at IS NULL`)
+- Skip indexes on low-cardinality columns (e.g. boolean with 50/50 split) — the planner won't use them
+- Trade-off: indexes speed up reads but slow down writes. For write-heavy tables with infrequent reads, keep indexing minimal
+
+### Text Search Strategies
+
+No Elasticsearch — apps use SQL/NoSQL via resource connectors. Choose the strategy based on dataset size:
+
+**Small datasets (<10k rows) — plain ILIKE:**
+
+```sql
+-- No special setup needed. Fast enough for small tables.
+SELECT * FROM users
+WHERE name ILIKE '%search%' OR email ILIKE '%search%';
+```
+
+**Medium datasets (10k–500k rows) — pg_trgm + GIN index:**
+
+```sql
+-- Setup (one-time): enable extension and create index
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX idx_users_name_trgm ON users USING GIN (name gin_trgm_ops);
+
+-- Query: same ILIKE, but now index-accelerated
+SELECT * FROM users
+WHERE name ILIKE '%search%' OR email ILIKE '%search%';
+```
+
+**Large datasets (500k+ rows) — tsvector full-text search:**
+
+```sql
+-- Setup: add a stored generated column + GIN index
+ALTER TABLE users ADD COLUMN search_vector tsvector
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce(name, '') || ' ' || coalesce(email, ''))) STORED;
+CREATE INDEX idx_users_fts ON users USING GIN (search_vector);
+
+-- Query: use plainto_tsquery for user input
+SELECT * FROM users
+WHERE search_vector @@ plainto_tsquery('english', 'search term')
+ORDER BY ts_rank(search_vector, plainto_tsquery('english', 'search term')) DESC;
+```
+
+**Non-Postgres sources** (Google Sheets, DynamoDB, external APIs):
+
+- Google Sheets: fetch all rows, filter client-side in static mode
+- DynamoDB: use FilterExpression on scan (slow) or design GSIs for searchable attributes
+- External APIs: delegate to API's own search params if available, else fetch and filter client-side
+
+### Postgres Pagination Techniques
+
+**OFFSET/LIMIT — use with `<DataTablePagination>`:**
+
+The standard approach. Works with the table's 0-based page index.
+
+```sql
+SELECT * FROM users
+WHERE ...
+ORDER BY created_at DESC
+LIMIT 50 OFFSET 100;  -- page 2, pageSize 50
+```
+
+Trade-offs:
+
+- Simple and works with arbitrary page jumps
+- Performance degrades on deep pages (Postgres must scan and discard `OFFSET` rows)
+- Fine for most tables (users rarely page past page 10–20)
+- If performance matters at depth 1000+, consider keyset pagination
+
+**Keyset/cursor pagination — use with `<DataTableInfiniteScroll>`:**
+
+For infinite scroll on very large datasets. Uses the last row's sort key as the cursor.
+
+```sql
+-- First page
+SELECT * FROM users ORDER BY created_at DESC, id DESC LIMIT 50;
+
+-- Next page (cursor = last row's created_at + id)
+SELECT * FROM users
+WHERE (created_at, id) < ($1, $2)
+ORDER BY created_at DESC, id DESC
+LIMIT 50;
+```
+
+Trade-offs:
+
+- Consistent performance regardless of depth
+- No arbitrary page jumps (forward-only)
+- Sort key must be unique or combined with a tiebreaker (e.g. `id`)
+- Great for infinite scroll; not suitable for offset pagination
+
+**Efficient COUNT:**
+
+For offset pagination, you need `totalCount` for the response:
+
+```sql
+-- Exact count — run in parallel with data query
+SELECT COUNT(*) FROM users WHERE ...;
+
+-- For very large tables (10M+), consider an approximate count when no filters applied:
+SELECT reltuples::bigint AS estimate FROM pg_class WHERE relname = 'users';
+-- This is a catalog estimate, updated by ANALYZE. Only use when precision isn't critical.
+```
+
+Best practice: run the COUNT and data query in parallel using `Promise.all` (shown in the route handler pattern above). This halves the perceived latency.
+
+### Export Route Handler
+
+Streaming CSV export endpoint. Applies the same filters/sort as the table but without pagination.
+
+```typescript
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+	const params = request.nextUrl.searchParams;
+
+	try {
+		const { whereClause, values } = buildWhereClause(params);
+		const orderBy = buildOrderBy(params);
+
+		// No LIMIT/OFFSET — fetch all matching rows
+		const result = await resourceClient.invoke(`SELECT * FROM users ${whereClause} ${orderBy}`, values, "export-users");
+
+		if (!result.ok) {
+			throw new Error("Database query failed");
+		}
+
+		// Build CSV
+		const headers = ["ID", "Name", "Email", "Role", "Created At"];
+		const csvRows = [
+			headers.join(","),
+			...result.result.rows.map((row) =>
+				[row.id, row.name, row.email, row.role, row.created_at]
+					.map((v) => `"${String(v ?? "").replace(/"/g, '""')}"`)
+					.join(","),
+			),
+		];
+		const csv = csvRows.join("\n");
+
+		return new NextResponse(csv, {
+			headers: {
+				"Content-Type": "text/csv",
+				"Content-Disposition": 'attachment; filename="users-export.csv"',
+			},
+		});
+	} catch (error) {
+		console.error("Export failed:", error);
+		return NextResponse.json(
+			{ success: false, error: { code: "EXPORT_FAILED", message: "Export failed" } },
+			{ status: 500 },
+		);
+	}
+}
+```
+
+Frontend usage with `<DataTableExport>`:
+
+```tsx
+import { DataTableExport, downloadFile } from "@/components/data-table";
+
+<DataTableExport
+	formatRows={(rows) => {
+		const headers = ["Name", "Email", "Role"];
+		return [headers.join(","), ...rows.map((r) => [r.name, r.email, r.role].map((v) => `"${v}"`).join(","))].join("\n");
+	}}
+	filename="users.csv"
+	onExportAll={async () => {
+		// Calls the export route with current filters applied
+		const params = buildRequestSearchParams(currentParams);
+		await downloadFile(`/api/users/export?${params}`);
+	}}
+/>;
+```
+
+---
+
+## Re-exported Primitives
+
+For custom table layouts that don't use `<DataTableContent>`:
+
+```tsx
+import {
+	Table,
+	TableHeader,
+	TableBody,
+	TableRow,
+	TableHead,
+	TableCell,
+	Button,
+	Input,
+	Checkbox,
+	Select,
+	SelectValue,
+	SelectTrigger,
+	SelectContent,
+	SelectItem,
+	DropdownMenu,
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+} from "@/components/data-table";
+```

--- a/plugins/major/skills/memory/SKILL.md
+++ b/plugins/major/skills/memory/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: using-memory
+description: Use this skill when you need to recall knowledge about the organization's resources, data patterns, or conventions from previous sessions. Memory is read-only — you can view and search existing memories but cannot create, edit, or delete them.
+---
+
+# Memory Tools
+
+Memory tools let you access knowledge recorded in previous coding sessions. Facts stored here are available to all sessions in this organization.
+
+**Memory is read-only for this agent.** You can view and search existing memory files to inform your work, but you cannot create, edit, or delete them.
+
+## Tools (on major-platform MCP server)
+
+| Tool                               | Purpose                          |
+| ---------------------------------- | -------------------------------- |
+| `mcp__major-platform__memory_view` | List files or view file contents |
+| `mcp__major-platform__memory_grep` | Search memory files by content   |
+
+## File Structure
+
+```
+memory/
+  organization/              # Org-wide knowledge
+    api-patterns.md          # Common API patterns, conventions
+    data-model.md            # Key data model facts
+    ...
+  resources/<resourceId>/    # Resource-specific knowledge
+    schema-notes.md          # Schema details, column meanings
+    query-patterns.md        # Common query patterns
+    ...
+```
+
+## When to Use
+
+Check memory at the start of a session or when working with resources to see if previous sessions recorded useful context (schema details, API patterns, conventions).
+
+## Examples
+
+**View all memory files:**
+
+```
+memory_view(path: "memory/")
+```
+
+**View resource-specific files:**
+
+```
+memory_view(path: "memory/resources/abc-123-def/")
+```
+
+**Search for relevant knowledge:**
+
+```
+memory_grep(pattern: "users table", file_glob: "memory/organization/**/*.md")
+```

--- a/plugins/major/skills/resources/ai-proxy/SKILL.md
+++ b/plugins/major/skills/resources/ai-proxy/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: using-ai-proxy
+description: Use when the user asks to add AI features, LLM calls, or chat functionality to their app. Covers Major's built-in AI proxy for Anthropic and OpenAI APIs.
+---
+
+## Major AI Proxy
+
+Major provides a built-in AI proxy that lets apps call Anthropic and OpenAI APIs without configuring API keys. Usage is billed at cost against the user's credits.
+
+## Workflow
+
+1. Call `check_ai_proxy_status` to see if the proxy is enabled for this app
+2. If enabled: use it directly with the env vars below
+3. If not enabled: ask the user if they want to enable it (recommended) or use their own API keys
+4. If user wants to enable it: call `enable_ai_proxy`
+
+## MCP Tools
+
+- `mcp__major-platform__check_ai_proxy_status` — Check if proxy is enabled and current month spend
+- `mcp__major-platform__enable_ai_proxy` — Enable the proxy for the current app
+
+## Environment Variables
+
+These env vars are already available in the app's runtime environment:
+
+- `MAJOR_AI_PROXY_URL` — Base URL for the AI proxy (set in `.env`)
+- `MAJOR_JWT_TOKEN` — Authentication token (set as pod env var). **You MUST pass this as the `apiKey` when initializing the SDK client.** The proxy authenticates every request using this token — requests without it will be rejected.
+
+They might not be available in your Bash, that's normal.
+
+## Code Examples
+
+### Anthropic
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+	baseURL: process.env.MAJOR_AI_PROXY_URL + "/anthropic",
+	apiKey: process.env.MAJOR_JWT_TOKEN,
+});
+
+const message = await client.messages.create({
+	model: "claude-sonnet-4-6",
+	max_tokens: 1024,
+	messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+### OpenAI — Chat
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+	baseURL: process.env.MAJOR_AI_PROXY_URL + "/openai",
+	apiKey: process.env.MAJOR_JWT_TOKEN,
+});
+
+const completion = await client.chat.completions.create({
+	model: "gpt-4.1",
+	messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+### OpenAI — Text-to-Speech
+
+```typescript
+const speech = await client.audio.speech.create({
+	model: "tts-1",
+	voice: "alloy",
+	input: "Hello, world!",
+});
+```
+
+### OpenAI — Speech-to-Text
+
+```typescript
+const transcription = await client.audio.transcriptions.create({
+	model: "whisper-1",
+	file: audioFile,
+});
+```
+
+## Available Models
+
+**Anthropic:**
+
+- `claude-opus-4-6` (flagship)
+- `claude-sonnet-4-6` (mid-tier)
+- `claude-haiku-4-5-20251001` (fast/cheap)
+
+**OpenAI:**
+
+- `gpt-5.4` (flagship)
+- `gpt-4.1` (mid-tier, 1M context)
+- `gpt-4.1-mini` (good value, 1M context)
+- `gpt-4.1-nano` (cheapest)
+- `o3` (reasoning)
+- `o4-mini` (fast reasoning)
+
+## Rules
+
+- Always use the native provider SDK (Anthropic or OpenAI) — never a unified SDK
+- Set `baseURL` to `process.env.MAJOR_AI_PROXY_URL + "/<provider>"` (e.g. `/anthropic` or `/openai`)
+- **Set `apiKey` to `process.env.MAJOR_JWT_TOKEN`** — this is required for authentication. Without it, all requests will be rejected.
+- Never hardcode API keys or proxy URLs
+- Only use models from the allowlist above
+
+## Available Endpoints
+
+Only these endpoints are available through the proxy:
+
+- **Anthropic:** `/v1/messages` (chat)
+- **OpenAI:** `/v1/chat/completions` (chat), `/v1/responses` (responses API), `/v1/audio/speech` (text-to-speech), `/v1/audio/transcriptions` (speech-to-text)
+
+## Limitations
+
+- No embeddings or image generation
+- Anthropic and OpenAI only
+- Monthly spending limits apply — requests are rejected if limit exceeded or wallet empty
+- Specific models from the allowlist only

--- a/plugins/major/skills/resources/bigquery/SKILL.md
+++ b/plugins/major/skills/resources/bigquery/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: using-bigquery-connector
+description: Implements BigQuery dataset exploration, SQL queries, and table operations using generated clients and MCP tools. Use when doing ANYTHING that touches BigQuery or BQ in any way, load this skill.
+---
+
+# Major Platform Resource: BigQuery
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__bigquery_list_datasets` — List all datasets in the project. Args: `resourceId`
+- `mcp__resources__bigquery_list_tables` — List tables in a dataset. Args: `resourceId`, `datasetId`
+- `mcp__resources__bigquery_describe_table` — Get schema and metadata for a table. Args: `resourceId`, `datasetId`, `tableId`
+- `mcp__resources__bigquery_query` — Execute read-only SQL (SELECT only). Args: `resourceId`, `statement`
+
+## TypeScript Client
+
+```typescript
+import { bqClient } from "./clients";
+
+// query(sql, params?, invocationKey, options?)
+const result = await bqClient.query(
+	"SELECT * FROM `project.dataset.table` WHERE created > @cutoff",
+	{ cutoff: "2024-01-01" },
+	"recent-records",
+	{ maxResults: 1000 },
+);
+
+// Other methods: listDatasets, listTables, getTable, insertRows, createTable
+```
+
+## Tips
+
+- **Be cost-aware** — BigQuery charges per bytes scanned. Use `SELECT specific_columns` instead of `SELECT *`. Use `LIMIT` during exploration.
+- Use `list_datasets` → `list_tables` → `describe_table` to understand data structure before querying
+- Use `maxResults` option for pagination of large result sets
+- Named parameters use `@param` syntax in queries
+
+**Docs**: [BigQuery Documentation](https://cloud.google.com/bigquery/docs)

--- a/plugins/major/skills/resources/cosmosdb/SKILL.md
+++ b/plugins/major/skills/resources/cosmosdb/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: using-cosmosdb-connector
+description: Implements Azure CosmosDB container queries, CRUD, and patch operations using generated clients and MCP tools. Use when doing ANYTHING that touches CosmosDB or Cosmos DB in any way, load this skill.
+---
+
+# Major Platform Resource: Azure CosmosDB
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__cosmosdb_list_containers` — List containers with partition key info. Args: `resourceId`
+- `mcp__resources__cosmosdb_describe_container` — Get partition key, indexing policy, unique keys. Args: `resourceId`, `container`
+- `mcp__resources__cosmosdb_get_container_stats` — Get document count and storage size. Args: `resourceId`, `container`
+- `mcp__resources__cosmosdb_query` — Execute a SQL query against a container. Args: `resourceId`, `container`, `query`, `parameters?`, `maxItemCount?`
+
+## TypeScript Client
+
+```typescript
+import { cosmosClient } from "./clients";
+
+// query<T>(container, query, invocationKey, options?)
+const result = await cosmosClient.query<User>(
+	"users",
+	"SELECT * FROM c WHERE c.status = @status",
+	"fetch-active-users",
+	{
+		parameters: [{ name: "@status", value: "active" }],
+		partitionKey: "tenant-acme",
+		maxItemCount: 50,
+	},
+);
+if (result.ok) {
+	console.log(result.result.documents);
+	// Handle pagination: result.result.continuationToken
+}
+
+// Other methods: read, create, upsert, replace, delete, patch
+await cosmosClient.patch<User>(
+	"users",
+	"user-456",
+	"tenant-acme",
+	[
+		{ op: "set", path: "/name", value: "Jane" },
+		{ op: "incr", path: "/loginCount", value: 1 },
+	],
+	"update-user",
+);
+```
+
+## Tips
+
+- **Partition key is required** for point operations (`read`, `replace`, `delete`, `patch`). Omit for cross-partition queries.
+- Use `patch()` for partial updates — more efficient than full `replace()`
+- Query parameters use `@param` syntax: `[{ name: "@status", value: "active" }]`
+- Use `continuationToken` from query results for pagination through large result sets
+
+**Docs**: [CosmosDB Documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/)

--- a/plugins/major/skills/resources/custom-api/SKILL.md
+++ b/plugins/major/skills/resources/custom-api/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: using-custom-api-connector
+description: Implements custom REST API HTTP requests with automatic auth header injection using generated clients and MCP tools. Use when doing ANYTHING that touches a custom API resource in any way, load this skill.
+---
+
+# Major Platform Resource: Custom REST API
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__custom_get` — Make a GET request to the configured API endpoint. Args: `resourceId`, `path`, `queryParams?`
+
+## TypeScript Client
+
+```typescript
+import { apiClient } from "./clients";
+
+// invoke(method, path, invocationKey, options?)
+const result = await apiClient.invoke("GET", "/users", "list-users", { query: { page: "1", limit: "20" } });
+if (result.ok) {
+	const response = result.result;
+	// response: { kind: "api", status: number, body: { kind: "json"|"text"|"binary", value: ... } }
+}
+
+// POST with body
+await apiClient.invoke("POST", "/users", "create-user", {
+	body: { type: "json", value: { name: "Jane", email: "jane@example.com" } },
+});
+```
+
+## Tips
+
+- **Paths are relative to the resource's configured base URL**
+- **Auth headers are automatically injected** — the resource configuration includes secret headers (e.g., Authorization) that you don't need to set manually
+- Supports all HTTP methods: GET, POST, PUT, PATCH, DELETE
+- Custom headers can be added via the `headers` option in the TypeScript client
+
+**Docs**: Refer to the specific API's documentation for endpoint details.

--- a/plugins/major/skills/resources/dynamodb/SKILL.md
+++ b/plugins/major/skills/resources/dynamodb/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: using-dynamodb-connector
+description: Implements DynamoDB queries, scans, and CRUD operations using generated clients and MCP tools. Use when doing ANYTHING that touches DynamoDB, DDB, or Dynamo in any way, load this skill.
+---
+
+# Major Platform Resource: DynamoDB
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__dynamodb_list_tables` — List all accessible tables. Args: `resourceId`, `limit?`
+- `mcp__resources__dynamodb_describe_table` — Get table schema, keys, indexes, throughput. Args: `resourceId`, `tableName`
+- `mcp__resources__dynamodb_scan` — Read-only scan with optional filter. Args: `resourceId`, `tableName`, `limit?`, `filterExpression?`, `projectionExpression?`
+
+## TypeScript Client
+
+```typescript
+import { myDynamoClient } from "./clients";
+
+// invoke<C>(command, params, invocationKey)
+const result = await myDynamoClient.invoke(
+	"Query",
+	{
+		TableName: "orders",
+		KeyConditionExpression: "user_id = :uid",
+		ExpressionAttributeValues: { ":uid": { S: userId } },
+		Limit: 20,
+		ScanIndexForward: false,
+	},
+	"fetch-user-orders",
+);
+
+if (result.ok) {
+	console.log(result.result.data.Items);
+}
+```
+
+## Tips
+
+- **Prefer Query over Scan** — Scan reads every item in the table and is expensive at scale
+- Use `describe_table` to understand key schema and indexes before writing queries
+- DynamoDB attribute values use marshall format (`{ S: "string" }`, `{ N: "123" }`, `{ BOOL: true }`)
+- TypeScript client supports all DynamoDB commands: `GetItem`, `PutItem`, `Query`, `Scan`, `UpdateItem`, `DeleteItem`, `BatchGetItem`, `BatchWriteItem`
+
+**Docs**: [DynamoDB Developer Guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/)

--- a/plugins/major/skills/resources/google-analytics/SKILL.md
+++ b/plugins/major/skills/resources/google-analytics/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: using-google-analytics-connector
+description: Implements Google Analytics (GA4) reporting, metadata exploration, and account management using generated clients and MCP tools. Use when doing ANYTHING that touches Google Analytics or GA4 in any way, load this skill.
+---
+
+# Major Platform Resource: Google Analytics
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-page-views"`, never dynamic values like `` `${date}-report` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__googleanalytics_run_report` — Run a GA4 report with dimensions, metrics, and date ranges. Args: `resourceId`, `dimensions`, `metrics`, `dateRanges`, `orderBys?`, `limit?`, `offset?`
+- `mcp__resources__googleanalytics_get_metadata` — Get available dimensions and metrics for the property. Args: `resourceId`
+- `mcp__resources__googleanalytics_run_realtime_report` — Run a realtime report showing live activity. Args: `resourceId`, `dimensions?`, `metrics`, `limit?`
+- `mcp__resources__googleanalytics_list_accounts` — List all GA4 accounts. Args: `resourceId`, `pageSize?`, `pageToken?`
+- `mcp__resources__googleanalytics_list_properties` — List GA4 properties, optionally by account. Args: `resourceId`, `accountId?`, `pageSize?`, `pageToken?`
+- `mcp__resources__googleanalytics_list_data_streams` — List data streams for a property. Args: `resourceId`, `propertyId?`, `pageSize?`, `pageToken?`
+- `mcp__resources__googleanalytics_invoke` — Execute any GA4 operation. Args: `resourceId`, `operation`, + operation-specific args
+
+## TypeScript Client
+
+```typescript
+import { gaClient } from "./clients";
+
+// runReport(dimensions, metrics, dateRanges, invocationKey, options?)
+const result = await gaClient.runReport(
+	[{ name: "country" }, { name: "city" }],
+	[{ name: "activeUsers" }, { name: "sessions" }],
+	[{ startDate: "30daysAgo", endDate: "today" }],
+	"traffic-by-location",
+	{ limit: 100 },
+);
+
+// getMetadata(invocationKey)
+const metadata = await gaClient.getMetadata("discover-dimensions");
+
+// listAccounts(invocationKey, options?)
+const accounts = await gaClient.listAccounts("list-ga-accounts");
+
+// listProperties(invocationKey, accountId?, options?)
+const properties = await gaClient.listProperties("list-ga-properties", "accounts/12345");
+
+// runRealtimeReport(metrics, invocationKey, dimensions?, limit?)
+const realtime = await gaClient.runRealtimeReport([{ name: "activeUsers" }], "live-users");
+```
+
+## Tips
+
+- **Property ID format**: Use the numeric GA4 property ID (e.g., `123456789`), not the measurement ID (G-XXXXXXXX). Find it in GA4 Admin > Property Settings.
+- **Date ranges**: Use relative dates like `today`, `yesterday`, `7daysAgo`, `30daysAgo`, or absolute dates in `YYYY-MM-DD` format.
+- **Discover available data**: Use `get_metadata` first to see which dimensions and metrics are available for the property before running reports.
+- **Dimension/metric names**: Use API names like `country`, `city`, `activeUsers`, `sessions`, `screenPageViews` — not display names.
+- **Realtime reports**: Do not support date ranges (they show live data only). Only a subset of dimensions/metrics are available.
+- **Pagination**: Use `limit` and `offset` for report results, `pageSize` and `pageToken` for list operations.
+
+**Docs**: [GA4 Data API](https://developers.google.com/analytics/devguides/reporting/data/v1) | [GA4 Admin API](https://developers.google.com/analytics/devguides/config/admin/v1)

--- a/plugins/major/skills/resources/googlesheets/SKILL.md
+++ b/plugins/major/skills/resources/googlesheets/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: using-googlesheets-connector
+description: Implements Google Sheets reading, writing, formatting, and batch operations using generated clients and MCP tools. Use when doing ANYTHING that touches Google Sheets or gsheets in any way, load this skill.
+---
+
+# Major Platform Resource: Google Sheets
+
+## Setting Up a Google Sheets Connector
+
+Google Sheets requires a two-step setup: (1) OAuth authentication, (2) spreadsheet selection.
+
+### When the user asks you to set up Google Sheets or connect a spreadsheet:
+
+1. Call `mcp__resource-setup__request-resource-setup` with `subtype: "googlesheets"` — this prompts the user to authenticate with Google
+2. After setup completes, call `mcp__resource-setup__request-resource-update` with the returned `resourceId` and `message: "Please select your spreadsheet. Click 'Configure Resource' below, then use the spreadsheet picker to choose your sheet."` — this prompts them to select their spreadsheet
+3. Once both steps complete, the resource is ready to use
+
+### When the user sends a Google Sheets link:
+
+If the user shares a Google Sheets URL (e.g., `https://docs.google.com/spreadsheets/d/...`), you cannot connect to it directly via the URL. Explain that they need to set up a Google Sheets connector:
+
+1. Tell them: "To connect to this spreadsheet, we need to set up a Google Sheets connector. This involves authenticating with Google and then selecting your spreadsheet."
+2. Follow the setup flow above (steps 1-3)
+3. After setup, the resource will be bound to the spreadsheet they select — remind them to pick the correct one
+
+### When a Google Sheets resource exists but has no spreadsheet selected:
+
+If you call a Google Sheets MCP tool and get an error indicating no spreadsheet is configured, use `mcp__resource-setup__request-resource-update` to prompt the user to select one.
+
+---
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__googlesheets_get_metadata` — Get spreadsheet metadata (title, locale, sheet info). Args: `resourceId`
+- `mcp__resources__googlesheets_get_values` — Read cell values from a range. Args: `resourceId`, `range`
+- `mcp__resources__googlesheets_list_sheets` — List all sheets (tabs) with properties. Args: `resourceId`
+
+## TypeScript Client
+
+**Prefer helper methods over raw `invoke()`:**
+
+```typescript
+import { sheetsClient } from "./clients";
+
+// Read values
+const values = await sheetsClient.getValues("Sheet1!A1:D10", "fetch-data");
+
+// Append rows
+await sheetsClient.appendValues("Sheet1!A:D", [["John", "Doe", "john@example.com", "2024-01-15"]], "append-row", {
+	valueInputOption: "USER_ENTERED",
+});
+
+// Update values
+await sheetsClient.updateValues(
+	"Sheet1!A1:B2",
+	[
+		["Name", "Email"],
+		["Jane", "jane@ex.com"],
+	],
+	"update-cells",
+);
+
+// Batch operations
+await sheetsClient.batchGetValues(["Sheet1!A1:B5", "Sheet2!A1:C3"], "batch-read");
+
+// Formatting via batchUpdate
+await sheetsClient.batchUpdate(
+	[
+		{
+			repeatCell: {
+				range: { sheetId: 0, startRowIndex: 0, endRowIndex: 1 },
+				cell: { userEnteredFormat: { textFormat: { bold: true } } },
+				fields: "userEnteredFormat.textFormat.bold",
+			},
+		},
+	],
+	"bold-header",
+);
+```
+
+## Tips
+
+- **Use helper methods** (`getValues`, `appendValues`, `updateValues`, `batchGetValues`, `batchUpdateValues`, `batchUpdate`) over raw `invoke()` when possible
+- Each resource is bound to a single spreadsheet — the spreadsheet ID is automatically included
+- For raw `invoke()`, paths are relative to `/v4/spreadsheets/{spreadsheetId}` (e.g., `/values/Sheet1!A1:D10`)
+- Use `valueInputOption: "USER_ENTERED"` to let Sheets parse formulas and dates
+
+**Docs**: [Google Sheets API Reference](https://developers.google.com/workspace/sheets/api/reference/rest)

--- a/plugins/major/skills/resources/graphql/SKILL.md
+++ b/plugins/major/skills/resources/graphql/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: using-graphql-connector
+description: Executes GraphQL queries and mutations against a configured endpoint using generated clients and MCP tools. Use when doing ANYTHING that touches a GraphQL resource in any way, load this skill.
+---
+
+# Major Platform Resource: GraphQL API
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__graphql_query` — Execute a read-only GraphQL query. Args: `resourceId`, `query`, `variables?`, `operationName?`, `headers?`, `timeoutMs?`
+- `mcp__resources__graphql_mutate` — Execute a GraphQL mutation (create, update, delete). Args: `resourceId`, `mutation`, `variables?`, `operationName?`, `headers?`, `timeoutMs?`
+- `mcp__resources__graphql_introspect` — Fetch the full GraphQL schema via introspection. Args: `resourceId`
+
+## TypeScript Client
+
+```typescript
+import { graphqlClient } from "./clients";
+
+// query(query, invocationKey, options?)
+const result = await graphqlClient.query(
+	`query GetUsers($limit: Int) {
+    users(limit: $limit) {
+      id
+      name
+      email
+    }
+  }`,
+	"list-users",
+	{ variables: { limit: 10 }, headers: { "X-Request-ID": "abc-123" } },
+);
+if (result.ok) {
+	const response = result.result;
+	// response: { kind: "api", status: number, body: { kind: "json", value: { data: { users: [...] } } } }
+}
+
+// mutate(mutation, invocationKey, options?)
+const createResult = await graphqlClient.mutate(
+	`mutation CreateUser($input: CreateUserInput!) {
+    createUser(input: $input) {
+      id
+      name
+    }
+  }`,
+	"create-user",
+	{ variables: { input: { name: "Jane", email: "jane@example.com" } } },
+);
+if (createResult.ok) {
+	console.log(createResult.result.body);
+}
+```
+
+## Tips
+
+- **Use variables** — always pass dynamic values via the `variables` parameter, never interpolate them into the query string
+- **GraphQL returns 200 even on errors** — check `response.body.value.errors` in addition to HTTP status. GraphQL errors are returned in the response body with a 200 status code
+- **Use introspection for schema discovery** — run `graphql_introspect` to see available types, queries, and mutations before writing queries
+- **Auth headers are automatically injected** — the resource configuration includes the authentication header that you don't need to set manually
+- **Per-request headers** — pass `headers` to include additional HTTP headers (e.g. `X-Request-ID`, tenant headers). Per-request headers override the resource's configured auth header if they use the same header name
+- Both `query` and `mutate` methods accept the same shape; `mutate` is semantically separated for clarity and MCP read-only enforcement
+
+**Docs**: Refer to the specific GraphQL API's documentation for schema details.

--- a/plugins/major/skills/resources/hubspot/SEARCH.md
+++ b/plugins/major/skills/resources/hubspot/SEARCH.md
@@ -1,0 +1,203 @@
+# HubSpot CRM Search API Reference
+
+**Endpoint:** `POST /crm/v3/objects/{objectType}/search`
+
+## Request Body
+
+All fields are optional. Send only what you need.
+
+```json
+{
+	"filterGroups": [],
+	"properties": ["prop1", "prop2"],
+	"sorts": [{ "propertyName": "createdate", "direction": "DESCENDING" }],
+	"limit": 20,
+	"after": "20",
+	"query": "search text"
+}
+```
+
+---
+
+## Filter Operators
+
+| Operator             | Value field           | Behavior                                                     |
+| -------------------- | --------------------- | ------------------------------------------------------------ |
+| `EQ`                 | `value`               | Exact match (case-insensitive except enums)                  |
+| `NEQ`                | `value`               | Not equal (case-insensitive except enums)                    |
+| `LT`                 | `value`               | Less than                                                    |
+| `LTE`                | `value`               | Less than or equal                                           |
+| `GT`                 | `value`               | Greater than                                                 |
+| `GTE`                | `value`               | Greater than or equal                                        |
+| `BETWEEN`            | `value` + `highValue` | Range (inclusive)                                            |
+| `IN`                 | `values` (array)      | Matches any in list. **String values must be lowercase.**    |
+| `NOT_IN`             | `values` (array)      | Excludes all in list. **String values must be lowercase.**   |
+| `HAS_PROPERTY`       | (none)                | Property has any value                                       |
+| `NOT_HAS_PROPERTY`   | (none)                | Property is empty/null                                       |
+| `CONTAINS_TOKEN`     | `value`               | Token match. Supports `*` wildcards for partial matching.    |
+| `NOT_CONTAINS_TOKEN` | `value`               | Excludes token. Supports `*` wildcards for partial matching. |
+
+**Common mistakes:**
+
+- Using `value` instead of `values` (array) for `IN`/`NOT_IN`
+- Forgetting `highValue` for `BETWEEN`
+- Passing a `value` for `HAS_PROPERTY`/`NOT_HAS_PROPERTY` (they take none)
+- Not lowercasing string values for `IN`/`NOT_IN`
+- Using `CONTAINS_TOKEN` without wildcards for partial matching — `"smith"` matches the whole token `"smith"` only, NOT `"Blacksmith"`. Use `"*smith*"` for partial matches.
+
+---
+
+## FilterGroups Logic
+
+- Filters **within** a filterGroup = **AND**
+- Multiple **filterGroups** = **OR**
+
+**Limits:**
+
+- Max **5** filterGroups
+- Max **6** filters per group
+- Max **18** filters total across all groups
+- Exceeding any limit returns `VALIDATION_ERROR`
+
+```json
+{
+	"filterGroups": [
+		{
+			"filters": [
+				{ "propertyName": "firstname", "operator": "EQ", "value": "Alice" },
+				{ "propertyName": "city", "operator": "EQ", "value": "Boston" }
+			]
+		},
+		{
+			"filters": [{ "propertyName": "email", "operator": "CONTAINS_TOKEN", "value": "*@example.com" }]
+		}
+	]
+}
+```
+
+This matches: (firstname=Alice AND city=Boston) OR (email contains @example.com)
+
+---
+
+## Case Sensitivity
+
+| Context                              | Behavior                                    |
+| ------------------------------------ | ------------------------------------------- |
+| Enumeration (dropdown) properties    | **Always case-sensitive** for all operators |
+| String properties with `IN`/`NOT_IN` | Values **must be lowercase**                |
+| All other string filters             | Case-insensitive                            |
+
+---
+
+## Date/Timestamp Values
+
+**CRITICAL: Use Unix epoch milliseconds as strings, NOT date strings.**
+
+| Property Type                                            | Format                                             | Notes                                                                    |
+| -------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------ |
+| **datetime** (e.g., `createdate`, `hs_lastmodifieddate`) | Unix ms as string: `"1642672800000"`               | Any valid ms timestamp                                                   |
+| **date-only** (no time component)                        | `YYYY-MM-DD` string OR Unix ms at **midnight UTC** | If using epoch ms, must be exactly midnight UTC or the date may be wrong |
+
+```json
+{
+	"filterGroups": [
+		{
+			"filters": [
+				{
+					"propertyName": "hs_lastmodifieddate",
+					"operator": "BETWEEN",
+					"value": "1579514400000",
+					"highValue": "1642672800000"
+				}
+			]
+		}
+	]
+}
+```
+
+**In TypeScript (via Major resource client):**
+
+```typescript
+const value = new Date("2024-01-01").getTime().toString(); // "1704067200000"
+
+const result = await hubspotClient.invoke("POST", "/crm/v3/objects/contacts/search", "search-contacts", {
+	body: {
+		filterGroups: [
+			{
+				filters: [
+					{
+						propertyName: "createdate",
+						operator: "GTE",
+						value: value,
+					},
+				],
+			},
+		],
+		properties: ["firstname", "lastname", "email"],
+	},
+});
+```
+
+---
+
+## Sorting
+
+- Only **1** sort rule per request
+- `direction`: `ASCENDING` or `DESCENDING`
+- Default (no sort): ordered by creation date, oldest first
+
+```json
+{ "sorts": [{ "propertyName": "createdate", "direction": "DESCENDING" }] }
+```
+
+---
+
+## Pagination
+
+- Default page size: **10**
+- Max page size: **200**
+- Max total results: **10,000** (paging beyond this returns 400)
+- Use `paging.next.after` from the response as the `after` parameter for the next page
+- When `paging.next.after` is absent, there are no more results
+
+---
+
+## Searching by Associations
+
+Use the pseudo-property `associations.{objectType}`:
+
+```json
+{ "propertyName": "associations.contact", "operator": "EQ", "value": "123" }
+```
+
+**Limitation:** Association searching is NOT supported for custom objects via search endpoints.
+
+---
+
+## Searchable Objects
+
+Contacts, companies, deals, tickets, products, quotes, line items, orders, invoices, carts, leads, discounts, fees, taxes, deal splits, feedback submissions, payments, subscriptions, and custom objects.
+
+**Engagement objects:** calls, emails, meetings, notes, tasks.
+
+### Default Searchable Properties (for `query` parameter)
+
+| Object    | Searchable Properties                                                                              |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| Contacts  | `firstname`, `lastname`, `email`, `phone`, `hs_additional_emails`, `fax`, `mobilephone`, `company` |
+| Companies | `website`, `phone`, `name`, `domain`                                                               |
+| Deals     | `dealname`, `pipeline`, `dealstage`, `description`, `dealtype`                                     |
+| Tickets   | `subject`, `content`, `hs_pipeline_stage`, `hs_ticket_category`, `hs_ticket_id`                    |
+| Products  | `name`, `description`, `price`, `hs_sku`                                                           |
+
+---
+
+## Limits & Gotchas
+
+- **Rate limit**: 5 requests/second per account for search (stricter than general API)
+- **Request body max**: 3,000 characters
+- **Newly created/updated objects** may take a few seconds to appear in search results
+- **Archived objects** never appear in results
+- **Cannot filter** engagement objects by `hs_body_preview_html`; emails also cannot filter by `hs_email_html` or `hs_body_preview`
+- **Phone numbers** are normalized — omit country code when searching
+- **Property names are case-sensitive** — use exact internal names from the CRM schema

--- a/plugins/major/skills/resources/hubspot/SKILL.md
+++ b/plugins/major/skills/resources/hubspot/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: using-hubspot-connector
+description: Implements HubSpot CRM data access for contacts, companies, and deals using generated clients and MCP tools. Use when doing ANYTHING that touches HubSpot in any way, load this skill.
+---
+
+# Major Platform Resource: HubSpot
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__hubspot_get` — Make a GET request to any HubSpot API endpoint. Args: `resourceId`, `path`, `queryParams?`
+- `mcp__resources__hubspot_list_contacts` — List contacts with optional property filtering. Args: `resourceId`, `properties?`, `limit?`
+- `mcp__resources__hubspot_list_companies` — List companies with optional property filtering. Args: `resourceId`, `properties?`, `limit?`
+- `mcp__resources__hubspot_list_deals` — List deals with optional property filtering. Args: `resourceId`, `properties?`, `limit?`
+
+## TypeScript Client
+
+```typescript
+import { hubspotClient } from "./clients";
+
+// invoke(method, path, invocationKey, options?)
+const result = await hubspotClient.invoke("GET", "/crm/v3/objects/contacts", "fetch-contacts", {
+	query: { limit: "10", properties: "firstname,lastname,email" },
+});
+if (result.ok && result.result.status === 200 && result.result.body.kind === "json") {
+	const contacts = result.result.body.value.results;
+}
+```
+
+## CRM Search API — [SEARCH.md](./SEARCH.md)
+
+Read **SEARCH.md** before doing any CRM search. It covers:
+
+- Filter operators (syntax, `value` vs `values` array, common mistakes)
+- FilterGroup AND/OR logic and hard limits (5 groups, 6 filters/group, 18 total)
+- **Date filters: epoch milliseconds as strings, NOT date strings**
+- Case sensitivity rules (enums, `IN`/`NOT_IN` lowercase requirement)
+- Sorting (1 rule max), pagination (200/page max, 10K total max)
+- Association searching, searchable properties per object, rate limits (5 req/s)
+
+---
+
+## Tips
+
+- **Use batch API calls when possible** — reduces API calls and avoids rate limits
+- **Rate limits**: General API = 100 requests per 10 seconds. **Search API = 5 requests per second** (stricter). Respect `Retry-After` headers.
+- Response structure: `{ kind: "api", status: number, body: { kind: "json", value: {...} } }`
+- Specify `properties` parameter to fetch only needed fields — improves performance
+
+**Docs**: [HubSpot API Reference](https://developers.hubspot.com/docs/api/overview)

--- a/plugins/major/skills/resources/lambda/SKILL.md
+++ b/plugins/major/skills/resources/lambda/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: using-lambda-connector
+description: Implements AWS Lambda function invocation and management using generated clients and MCP tools. Use when doing ANYTHING that touches Lambda or AWS Lambda in any way, load this skill.
+---
+
+# Major Platform Resource: AWS Lambda
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__lambda_list_functions` — List accessible Lambda functions. Args: `resourceId`, `maxItems?`
+- `mcp__resources__lambda_get_function` — Get function config and code location. Args: `resourceId`, `functionName`, `qualifier?`
+- `mcp__resources__lambda_invoke` — Invoke a function. Args: `resourceId`, `functionName`, `payload?`, `invocationType?`, `qualifier?`
+
+## TypeScript Client
+
+```typescript
+import { lambdaClient } from "./clients";
+
+// invoke(functionName, payload, invocationKey, options?)
+const result = await lambdaClient.invoke("my-function", { userId: "123", action: "process" }, "invoke-processor", {
+	invocationType: "RequestResponse",
+});
+if (result.ok) {
+	console.log(result.result);
+}
+```
+
+## Tips
+
+- **Invocation types**: `RequestResponse` (synchronous, default), `Event` (async fire-and-forget), `DryRun` (validate without executing)
+- Payload size limit: 6MB for synchronous, 256KB for async invocations
+- Use `qualifier` to invoke a specific version or alias (defaults to `$LATEST`)
+
+**Docs**: [AWS Lambda Documentation](https://docs.aws.amazon.com/lambda/)

--- a/plugins/major/skills/resources/list-resources/SKILL.md
+++ b/plugins/major/skills/resources/list-resources/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: list-resources
+description: Use this skill whenever you need to discover or work with resources (databases, APIs, storage, etc.) available to the application. Load this skill before doing any work that involves resources.
+---
+
+# Discovering and Using Resources
+
+The application has been granted access to resources — external services (databases, APIs, storage, etc.) that your application can interact with through Major's secure clients.
+
+## Step 1: List available resources
+
+Call `mcp__resources__list_resources` to get all resources the application has access to.
+
+## Step 2: Check for context documents before doing any work
+
+**Always call `mcp__resources__list_resource_context` for every resource before doing any other work with it.** Resources often have context documents attached (API docs, schema references, usage guides) that tell you exactly how to use them.
+
+For each resource you plan to use:
+
+1. Call `mcp__resources__list_resource_context` with the `resourceId` immediately after listing resources
+2. **If documents exist, you MUST read them before doing anything else with the resource.** Do NOT skip this step. Do NOT query the resource directly until you have read all relevant context documents. The user uploaded these documents specifically to guide how you use the resource.
+3. For each relevant document, spawn the `file-reader` agent to download and read it:
+   ```
+   Task tool with subagent_type: "file-reader"
+   Prompt: "Download and read this resource context document.
+     resourceId: <id>, documentId: <id>, filename: <name from list>
+     Extract: <what information you need for your current task>"
+   ```
+   The agent will download the file, read it, and return a summary plus the local file path.
+4. If the context document contains schema or API information, use it directly — do not make redundant queries (e.g. do not run `\d` table commands if the schema is already in the context doc)
+5. Tell the user which context documents you read and what you learned, so they know their context is being used

--- a/plugins/major/skills/resources/majorauth/SKILL.md
+++ b/plugins/major/skills/resources/majorauth/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: using-auth-connector
+description: Share or revoke application access for users by email. Use whenever the app needs to manage user access to the app.
+---
+
+# Major Platform Resource: Major Auth Connector
+
+## Common: Interacting with Resources
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"share-user-access"`, never dynamic values like `` `${date}-share` ``.
+
+---
+
+## How to Use
+
+The Major Auth Connector is a **managed resource** that exists by default in every organization. To use it:
+
+1. Call `mcp__resources__list_resources` to discover available resources — look for the one with subtype `majorauth` (named "Major Auth Connector").
+2. Call `mcp__resource-tools__add-resource-client` with that `resourceId` to generate a typed `MajorAuthResourceClient`.
+3. Use the generated client in your app code to share or revoke access.
+
+## MCP Tools
+
+- `mcp__resources__majorauth_share_access` — Grant a user view access to the current app by email. Creates user account and org membership if needed. Args: `resourceId`, `email`
+- `mcp__resources__majorauth_revoke_access` — Revoke a user's view access to the current app by email. Only removes app-level access; does not affect org membership. Args: `resourceId`, `email`
+
+## TypeScript Client
+
+```typescript
+import { authClient } from "./clients";
+
+// Grant a user view access to the app by email
+// Creates their account and org membership if they don't exist
+const shareResult = await authClient.shareAccess("user@example.com", "share-user-access");
+if (shareResult.ok) {
+	console.log("Access granted:", shareResult.result.success);
+}
+
+// Revoke a user's app access (does NOT remove them from the org)
+const revokeResult = await authClient.revokeAccess("user@example.com", "revoke-user-access");
+if (revokeResult.ok) {
+	console.log("Access revoked:", revokeResult.result.success);
+}
+```
+
+## Tips
+
+- **View access only**: `shareAccess` grants `Application:User` role which gives view access to the app. It does not grant edit or admin permissions.
+- **Auto-creates users**: If the email doesn't have an account, one is automatically created and added to the organization.
+- **Idempotent**: Calling `shareAccess` for a user who already has access is safe and will not error.
+- **Revoke is app-scoped**: `revokeAccess` only removes the user's access to this specific app. It does not remove them from the organization or affect any other apps.
+- **If a user is NOT invited through this connector, they will get redirected out of the app when they try to enter the app**

--- a/plugins/major/skills/resources/managed-database/SKILL.md
+++ b/plugins/major/skills/resources/managed-database/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: using-managed-database
+description: Set up and use Major-managed PostgreSQL databases. Use when the user wants a database, needs to store data, mentions "managed database", or asks about database setup.
+---
+
+# Major Platform: Managed Databases
+
+## What is a Managed Database?
+
+A managed database is a Major-hosted PostgreSQL instance provisioned and managed entirely by the platform. No credentials to manage, no connection strings to configure — everything is handled automatically. Once active, it appears as a regular PostgreSQL resource with `isManaged: true`.
+
+## App-Scoped vs Org-Scoped
+
+There are two types of managed databases:
+
+- **App-scoped** (created by this tool): Belongs to a single application. Permissions are automatically inherited from app roles — app admins and editors get `Resource:Admin` on the database. Other apps cannot access it.
+- **Org-scoped**: Shared across all apps in the organization. Created by org admins through the dashboard. Visible to all apps with appropriate permissions.
+
+The `setup_managed_database` MCP tool creates **app-scoped** databases only.
+
+## Setting Up a Managed Database
+
+Call `mcp__resources__setup_managed_database` — no arguments needed. The tool automatically provisions a database for the current application.
+
+**Behavior:**
+
+- **First call** (no database exists): Starts provisioning. Takes around 1 minute.
+- **While provisioning**: Returns status. Wait ~1 minute and call again.
+- **Once active**: Returns the resource ID. The database is ready to use.
+- **If failed**: Returns failure status. Deprovision and try again.
+
+## Using the Database Once Active
+
+After setup completes and you have the resource ID:
+
+1. **MCP tools** (direct SQL, no code needed):
+   - `mcp__resources__postgresql_psql` — Read-only SQL queries and psql commands (`\dt`, `\d`, etc.). Args: `resourceId`, `command`
+   - `mcp__resources__postgresql_run_migration` — DDL/DML migrations (managed databases only). Args: `resourceId`, `migration`, `description?`
+
+2. **Generated TypeScript clients** (for app code):
+   - Call `mcp__resource-tools__add-resource-client` with the `resourceId` to generate a typed PostgreSQL client
+   - Use the client for read/write operations in your application code
+
+## Identifying Managed Databases
+
+In `mcp__resources__list_resources`, managed databases have `isManaged: true` and a `managedScope` field:
+
+- `managedScope: "app"` — App-scoped, belongs to this application only
+- `managedScope: "org"` — Org-scoped, shared across all apps in the organization
+
+The `postgresql_run_migration` tool only works on managed databases. Regular (external) PostgreSQL resources have `isManaged: false`.
+
+## Choosing Between App and Org Databases
+
+If the user has both an app-scoped and an org-scoped managed database available, **ask the user which one they want to use** before proceeding. Do not assume. For example: "I see you have both an app database and an organization-wide database. Which one should I use for this task?"
+
+If there is only an app-scoped database just use that one, don't ask. If there is only an org-scoped database, ask the user if they'd like to make a new app-scoped db. Generally, it's better to use an app DB unless there's a real
+reason that data that should be shared for the entire org.
+
+## Tips
+
+- Use `postgresql_psql` for read-only exploration (schema inspection, SELECT queries)
+- Use `postgresql_run_migration` for all schema changes and data modifications on managed databases
+- Use parameterized queries (`$1`, `$2`, ...) — never interpolate values into SQL strings
+- After creating tables with `run_migration`, generate a TypeScript client for the app to use in code

--- a/plugins/major/skills/resources/mssql/SKILL.md
+++ b/plugins/major/skills/resources/mssql/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: using-mssql-connector
+description: Implements Microsoft SQL Server connections, queries, and schema exploration using generated clients and MCP tools. Use when doing ANYTHING that touches MSSQL, SQL Server, or T-SQL in any way, load this skill.
+---
+
+# Major Platform Resource: Microsoft SQL Server
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__mssql_list_schemas` — List all schemas (excludes system schemas). Args: `resourceId`
+- `mcp__resources__mssql_list_tables` — List tables, optionally filtered by schema. Args: `resourceId`, `schema?`
+- `mcp__resources__mssql_list_columns` — List columns with types/constraints for a table. Args: `resourceId`, `schema`, `table`
+- `mcp__resources__mssql_query` — Execute read-only SQL (SELECT/WITH only). Args: `resourceId`, `statement`, `params?`
+
+## TypeScript Client
+
+```typescript
+import { myMssqlClient } from "./clients";
+
+// invoke<T>(sql, params?, invocationKey, timeoutMs?)
+// Uses named parameters: @paramName
+const result = await myMssqlClient.invoke<{ id: number; name: string }>(
+	"SELECT * FROM users WHERE id = @id",
+	{ id: userId },
+	"fetch-user",
+);
+if (result.ok) {
+	console.log(result.result.rows);
+}
+```
+
+## Tips
+
+- Uses **named parameters** (`@id`, `@name`) not positional (`$1`)
+- MCP query tool only allows SELECT/WITH — no multi-statement queries
+- Use `list_schemas` → `list_tables` → `list_columns` to explore database structure
+
+**Docs**: [SQL Server Documentation](https://learn.microsoft.com/en-us/sql/sql-server/)

--- a/plugins/major/skills/resources/neo4j/SKILL.md
+++ b/plugins/major/skills/resources/neo4j/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: using-neo4j-connector
+description: Implements Neo4j Cypher queries, graph traversal, and node/relationship operations using generated clients and MCP tools. Use when doing ANYTHING that touches Neo4j or Cypher in any way, load this skill.
+---
+
+# Major Platform Resource: Neo4j
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__neo4j_query` — Execute read-only Cypher (MATCH/CALL/SHOW/WITH/RETURN only). Args: `resourceId`, `cypher`, `params?`, `maxResults?`
+- `mcp__resources__neo4j_list_node_labels` — List all node labels. Args: `resourceId`
+- `mcp__resources__neo4j_list_relationship_types` — List all relationship types. Args: `resourceId`
+- `mcp__resources__neo4j_describe_schema` — Get constraints and indexes. Args: `resourceId`
+
+## TypeScript Client
+
+```typescript
+import { graphDbClient } from "./clients";
+
+// invoke(cypher, params?, invocationKey, timeoutMs?)
+// Uses named parameters: $paramName
+const result = await graphDbClient.invoke(
+	"MATCH (u:User {email: $email})-[:PURCHASED]->(p:Product) RETURN u, p LIMIT 10",
+	{ email: "jane@example.com" },
+	"fetch-user-purchases",
+);
+if (result.ok) {
+	const { records, keys } = result.result;
+	for (const record of records) {
+		console.log(record["u"].properties.name);
+	}
+}
+```
+
+## Response Shape
+
+Graph types are converted to plain objects with a `_type` discriminator:
+
+| Neo4j Type   | Shape                                                                                    |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| Node         | `{ _type: "node", _id, labels, properties }`                                             |
+| Relationship | `{ _type: "relationship", _id, _startNodeId, _endNodeId, relationshipType, properties }` |
+| Path         | `{ _type: "path", nodes[], relationships[] }`                                            |
+
+## Tips
+
+- Uses **named parameters** (`$email`) not positional — pass `undefined` when no params needed
+- MCP query tool is read-only; use the TypeScript client for CREATE/MERGE/DELETE operations
+- Use `list_node_labels` and `list_relationship_types` to explore the graph structure before querying
+
+**Docs**: [Neo4j Cypher Manual](https://neo4j.com/docs/cypher-manual/current/)

--- a/plugins/major/skills/resources/outreach/SKILL.md
+++ b/plugins/major/skills/resources/outreach/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: using-outreach-connector
+description: Implements Outreach prospect and sequence management using generated clients and MCP tools. Use when doing ANYTHING that touches Outreach or Outreach.io in any way, load this skill.
+---
+
+# Major Platform Resource: Outreach
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__outreach_get` — Make a GET request to any Outreach API endpoint. Args: `resourceId`, `path`, `queryParams?`
+- `mcp__resources__outreach_list_prospects` — List prospects with pagination. Args: `resourceId`, `limit?`
+- `mcp__resources__outreach_list_sequences` — List sequences with pagination. Args: `resourceId`, `limit?`
+
+## TypeScript Client
+
+```typescript
+import { outreachClient } from "./clients";
+
+// invoke(method, path, invocationKey, options?)
+const result = await outreachClient.invoke("GET", "/api/v2/prospects", "list-prospects", {
+	queryParams: { "page[limit]": "10" },
+});
+if (result.ok) {
+	console.log(result.result.data);
+}
+
+// Create a prospect — uses JSON:API format
+await outreachClient.invoke("POST", "/api/v2/prospects", "create-prospect", {
+	body: {
+		data: {
+			type: "prospect",
+			attributes: { firstName: "John", lastName: "Doe", emails: ["john@example.com"] },
+		},
+	},
+});
+```
+
+## Tips
+
+- **Request bodies use JSON:API format**: `{ data: { type: "...", attributes: {...} } }`
+- Pagination uses `page[limit]` and `page[offset]` query parameters
+- Paths include the full API path: `/api/v2/prospects`, `/api/v2/sequences`, etc.
+
+**Docs**: [Outreach API Reference](https://developers.outreach.io/api/reference/)

--- a/plugins/major/skills/resources/postgresql/SKILL.md
+++ b/plugins/major/skills/resources/postgresql/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: using-postgresql-connector
+description: Implements PostgreSQL connections, SQL queries, and migration patterns using generated clients and MCP tools. Use when doing ANYTHING that touches PostgreSQL, Postgres, pg, or psql in any way, load this skill.
+---
+
+# Major Platform Resource: PostgreSQL
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__postgresql_psql` — Execute read-only SQL queries and psql backslash commands (`\dt`, `\d`, `\di`, `\df`, etc.). Args: `resourceId`, `command`, `timeoutMs?`
+- `mcp__resources__postgresql_run_migration` — Run DDL/DML migrations on **managed databases only** (`isManaged=true`). Runs in a transaction; rolls back on failure. Args: `resourceId`, `migration`, `description?`
+
+## TypeScript Client
+
+```typescript
+import { myDbClient } from "./clients";
+
+// invoke<T>(sql, params?, invocationKey, timeoutMs?)
+const result = await myDbClient.invoke<{ id: number; name: string }>(
+	"SELECT * FROM users WHERE id = $1",
+	[userId],
+	"fetch-user",
+);
+if (result.ok) {
+	console.log(result.result.rows);
+}
+```
+
+## Tips
+
+- Use parameterized queries (`$1`, `$2`, ...) — never interpolate values into SQL strings
+- `psql` tool is read-only; use `run_migration` for writes (managed DBs) or the TypeScript client for writes (external DBs)
+- The TypeScript client supports full read/write operations regardless of managed status
+- Use `psql` exclusively for read-only tasks. Never use invoke for read only.
+
+**Docs**: [PostgreSQL Documentation](https://www.postgresql.org/docs/)

--- a/plugins/major/skills/resources/quickbooks/SKILL.md
+++ b/plugins/major/skills/resources/quickbooks/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: using-quickbooks-connector
+description: Implements QuickBooks Online accounting data access for customers, invoices, items, accounts, vendors, bills, and payments using generated clients and MCP tools. Use when doing ANYTHING that touches QuickBooks in any way, load this skill.
+---
+
+# Major Platform Resource: QuickBooks Online
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__quickbooks_query` — Execute a QuickBooks query using SQL-like syntax. Args: `resourceId`, `query`, `timeoutMs?`
+- `mcp__resources__quickbooks_get` — Get a specific entity by type and ID. Args: `resourceId`, `entityType`, `entityId`
+- `mcp__resources__quickbooks_invoke` — Make any HTTP request to the QuickBooks API, including write operations. Args: `resourceId`, `method`, `path`, `query?`, `body?`, `timeoutMs?`
+
+## TypeScript Client
+
+```typescript
+import { qbClient } from "./clients";
+
+// Query entities using SQL-like syntax
+const result = await qbClient.query("SELECT * FROM Customer WHERE DisplayName LIKE 'A%'", "search-customers");
+if (result.ok && result.result.body.kind === "json") {
+	const data = result.result.body.value;
+}
+
+// Generic invoke for any operation
+const invoice = await qbClient.invoke("GET", "/invoice/123", "get-invoice");
+
+// Create an invoice
+const newInvoice = await qbClient.invoke("POST", "/invoice", "create-invoice", {
+	body: {
+		type: "json",
+		value: {
+			Line: [{ Amount: 100.0, DetailType: "SalesItemLineDetail" }],
+			CustomerRef: { value: "1" },
+		},
+	},
+});
+```
+
+## Tips
+
+- **QuickBooks Query Language** is SQL-like but has limitations:
+  - No JOINs, no OR in WHERE clauses, no GROUP BY
+  - Use `LIKE` with `%` for wildcard matching
+  - Only filterable properties can be used in WHERE clauses
+  - Example: `SELECT * FROM Invoice WHERE TotalAmt > '100.00'`
+- **Common entity types**: Customer, Invoice, Item, Account, Vendor, Bill, Payment, Estimate, PurchaseOrder, SalesReceipt, CreditMemo, Employee
+- **All API paths are relative** to `/v3/company/{realmId}` — the realmId is handled automatically
+- **Rate limit**: 500 requests per minute per realm. Respect throttling headers.
+- Response structure: `{ kind: "api", status: number, body: { kind: "json", value: {...} } }`
+- **Updates require SyncToken**: When updating entities, include the current `SyncToken` from the entity to prevent conflicts
+
+**Docs**: [QuickBooks Online API Reference](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/account)

--- a/plugins/major/skills/resources/s3/SKILL.md
+++ b/plugins/major/skills/resources/s3/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: using-s3-connector
+description: Implements Amazon S3 object operations, presigned URLs, and file uploads/downloads using generated clients and MCP tools. Use when doing ANYTHING that touches S3 or AWS S3 in any way, load this skill.
+---
+
+# Major Platform Resource: Amazon S3
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__s3_list_buckets` — List all accessible buckets. Args: `resourceId`
+- `mcp__resources__s3_list_objects` — List objects with optional prefix/delimiter. Args: `resourceId`, `bucket`, `prefix?`, `delimiter?`, `maxKeys?`
+- `mcp__resources__s3_get_object_metadata` — Get size, content type, last modified. Args: `resourceId`, `bucket`, `key`
+
+## TypeScript Client
+
+```typescript
+import { storageClient } from "./clients";
+
+// Generate presigned URL for upload
+const uploadResult = await storageClient.invoke(
+	{ command: "PutObject", key: "uploads/image.jpg", presignedUrl: true, expiresIn: 3600 },
+	"generate-upload-url",
+);
+if (uploadResult.ok) {
+	const url = uploadResult.result.presignedUrl;
+	// Return URL to frontend for direct upload
+}
+
+// List objects
+const listResult = await storageClient.invoke({ command: "ListObjectsV2", prefix: "uploads/" }, "list-uploads");
+```
+
+## Tips
+
+- **Always use presigned URLs** for uploads and downloads — generate on server, return URL to frontend for direct S3 access
+- **Never proxy file contents** through your application server
+- S3 commands: `PutObject`, `GetObject`, `ListObjectsV2`, `DeleteObject`, `HeadObject`
+- Compatible with AWS S3, MinIO, DigitalOcean Spaces, and other S3-compatible storage
+
+**Docs**: [Amazon S3 Documentation](https://docs.aws.amazon.com/s3/)

--- a/plugins/major/skills/resources/salesforce/SKILL.md
+++ b/plugins/major/skills/resources/salesforce/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: using-salesforce-connector
+description: Implements Salesforce SOQL queries, sObject CRUD, and metadata exploration using generated clients and MCP tools. Use when doing ANYTHING that touches Salesforce, SFDC, or SOQL in any way, load this skill.
+---
+
+# Major Platform Resource: Salesforce
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__salesforce_get` — Make a GET request to any Salesforce API endpoint. Args: `resourceId`, `path`, `queryParams?`
+- `mcp__resources__salesforce_query` — Execute a SOQL query. Args: `resourceId`, `query`
+- `mcp__resources__salesforce_describe_object` — Get metadata and field definitions for an sObject. Args: `resourceId`, `objectType`
+
+## TypeScript Client
+
+```typescript
+import { sfClient } from "./clients";
+
+// Prefer helper methods over raw invoke()
+const result = await sfClient.query(
+	"SELECT Id, Name FROM Account WHERE CreatedDate > 2024-01-01T00:00:00Z LIMIT 10",
+	"recent-accounts",
+);
+
+// CRUD helpers
+await sfClient.getRecord("Account", recordId, "get-account", { fields: ["Name", "Industry"] });
+await sfClient.createRecord("Account", { Name: "Acme Corp" }, "create-account");
+await sfClient.updateRecord("Account", recordId, { Name: "Updated" }, "update-account");
+await sfClient.deleteRecord("Account", recordId, "delete-account");
+await sfClient.describeObject("Account", "describe-account");
+```
+
+## Tips
+
+- **Use `query()` helper for SOQL** — cleaner than building the path manually
+- **Governor limits**: Be mindful of API call limits (varies by org edition). Use bulk API for large data operations.
+- Use `describeObject()` to explore field names and types before writing queries
+- Salesforce API paths include the version: `/services/data/v63.0/...`
+
+**Docs**: [Salesforce REST API Reference](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/)

--- a/plugins/major/skills/resources/slack/SKILL.md
+++ b/plugins/major/skills/resources/slack/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: using-slack-connector
+description: Implements Slack messaging, channel operations, and Web API calls using generated clients and MCP tools. Use when doing ANYTHING that touches Slack in any way, load this skill.
+---
+
+# Major Platform Resource: Slack
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## CRITICAL: Channel Access Verification
+
+Before sending messages, posting files, or reading history from any channel, you MUST verify the bot has access to that channel. **Never attempt to post to a channel without confirming access first.**
+
+**Required workflow:**
+
+1. Call `mcp__resources__slack_list_channels` to get the list of channels the bot can see.
+2. Check if the target channel appears in the results.
+3. **If the channel is NOT in the list:** Tell the user that the bot does not currently have access to that channel. Ask them to invite the bot by going to the channel and @mentioning **@Major Slack Integration**. Once the user confirms they have done this, call `mcp__resources__slack_list_channels` again to verify the channel now appears.
+4. **Only after the channel is confirmed visible** in the list may you proceed with sending messages, reading history, or any other channel operation.
+
+**Do NOT skip this check.** Do NOT assume the bot has access to a channel just because the user mentioned it by name.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__slack_call` — Call any Slack Web API method. Args: `resourceId`, `method`, `body?`
+- `mcp__resources__slack_list_channels` — List channels in the workspace. Args: `resourceId`, `limit?`
+- `mcp__resources__slack_post_message` — Post a message to a channel. Args: `resourceId`, `channel`, `text`, `blocks?`
+- `mcp__resources__slack_get_history` — Get message history from a channel. Args: `resourceId`, `channel`, `limit?`
+
+## TypeScript Client
+
+```typescript
+import { slackClient } from "./clients";
+
+// invoke(method, invocationKey, options?)
+// The `method` parameter is the Slack API method name
+const result = await slackClient.invoke("chat.postMessage", "post-update", {
+	body: { channel: "C0123456", text: "Hello from the app!" },
+});
+
+// List channels
+await slackClient.invoke("conversations.list", "list-channels", {
+	body: { limit: 100 },
+});
+
+// getUploadURL(filename, length, invocationKey, options?)
+// completeUpload(files, channelId, invocationKey, options?)
+// See "File Upload" section below for usage
+```
+
+## File Upload
+
+Slack uses a 3-step flow for uploading files/images to channels:
+
+```typescript
+import { slackClient } from "./clients";
+
+// Step 1: Get a pre-signed upload URL
+const urlResult = await slackClient.getUploadURL(
+	"chart.png", // filename with extension
+	fileBytes.length, // file size in bytes
+	"get-upload-url",
+);
+if (!urlResult.ok) throw new Error(urlResult.error.message);
+const { upload_url, file_id } = urlResult.result.body.value;
+
+// Step 2: Upload the file binary to the pre-signed URL
+await fetch(upload_url, {
+	method: "POST",
+	headers: { "Content-Type": "application/octet-stream" },
+	body: fileBytes,
+});
+
+// Step 3: Complete the upload and share to a channel
+const completeResult = await slackClient.completeUpload(
+	[{ id: file_id, title: "Weekly Chart" }],
+	"C0123456", // channel ID
+	"complete-upload",
+	{ initialComment: "Here's this week's chart" },
+);
+```
+
+- The upload URL from step 1 is temporary — complete all 3 steps without delay
+- Step 2 is a direct HTTP POST (no auth needed, the URL is pre-signed)
+- You can upload multiple files by calling step 1+2 for each, then passing all file IDs to a single step 3
+- Use `threadTs` in step 3 options to upload into a thread
+- Requires `files:write` OAuth scope (included in the "Read & Write" preset)
+
+## Tips
+
+- The `method` param is the **Slack API method name** (e.g., `chat.postMessage`, `conversations.list`, `users.list`)
+- For the TypeScript client, all parameters go in the `body` option — Slack's Web API uses POST with JSON body
+- Check [Slack API methods list](https://api.slack.com/methods) for available methods and their parameters
+
+**Docs**: [Slack API Reference](https://api.slack.com/methods)

--- a/plugins/major/skills/resources/snowflake/SKILL.md
+++ b/plugins/major/skills/resources/snowflake/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: using-snowflake-connector
+description: Implements Snowflake warehouse queries, schema exploration, and data operations using generated clients and MCP tools. Use when doing ANYTHING that touches Snowflake in any way, load this skill.
+---
+
+# Major Platform Resource: Snowflake
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
+
+**Two ways to interact with resources:**
+
+1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.
+2. **Generated TypeScript clients** (for app code): Call `mcp__resource-tools__add-resource-client` with a `resourceId` to generate a typed client. Clients are created in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess client method names or signatures.** The TypeScript clients in `@major-tech/resource-client` have strongly typed inputs and outputs. ALWAYS read the actual client source code in the generated `/clients/` directory (or the package itself) to verify available methods and their exact signatures before writing any client code.
+
+**Framework note**: Next.js = resource clients must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**Error handling**: Always check `result.ok` before accessing `result.result`.
+
+**Invocation keys must be static strings** — use descriptive literals like `"fetch-user-orders"`, never dynamic values like `` `${date}-records` ``.
+
+---
+
+## MCP Tools
+
+- `mcp__resources__snowflake_list_databases` — List all accessible databases. Args: `resourceId`
+- `mcp__resources__snowflake_list_schemas` — List schemas in a database. Args: `resourceId`, `database`
+- `mcp__resources__snowflake_list_tables` — List tables in a schema. Args: `resourceId`, `database`, `schema`
+- `mcp__resources__snowflake_query` — Execute read-only SQL (SELECT/SHOW/DESCRIBE/EXPLAIN). Args: `resourceId`, `statement`, `database?`, `schema?`
+
+## TypeScript Client
+
+```typescript
+import { snowflakeClient } from "./clients";
+
+// execute(statement, invocationKey, options?)
+const result = await snowflakeClient.execute(
+	"SELECT * FROM orders WHERE order_date > '2024-01-01' LIMIT 100",
+	"recent-orders",
+	{ database: "ANALYTICS", schema: "PUBLIC" },
+);
+
+// status(statementHandle, invocationKey, options?) — for async queries
+// cancel(statementHandle, invocationKey)
+```
+
+## Tips
+
+- MCP tools are **all read-only** — use the TypeScript client for write operations
+- Use `list_databases` → `list_schemas` → `list_tables` to explore data warehouse structure
+- The `query` tool accepts optional `database` and `schema` context parameters
+- For long-running queries via the TypeScript client, use async execution with `status()` polling
+
+**Docs**: [Snowflake Documentation](https://docs.snowflake.com/)

--- a/plugins/major/skills/webhooks/SKILL.md
+++ b/plugins/major/skills/webhooks/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: using-webhooks
+description: Explains how webhook access works on deployed Major apps and how to implement webhook endpoints. Use when the user mentions webhooks, needs to receive external HTTP callbacks, or is integrating with services that send webhooks (e.g., Stripe, GitHub, Twilio).
+---
+
+# Major Platform: Webhooks
+
+## Overview
+
+Major apps are protected by an authentication gateway by default. Enabling **Webhook Access** allows unauthenticated HTTP traffic to reach routes matching `/api/webhook/*` on **deployed apps only**. This is required for receiving callbacks from external services like Stripe, GitHub, Twilio, etc.
+
+**Important:** Webhook access simply allows traffic through — it does NOT perform any authentication or verification. If the webhook provider supports authentication (e.g., Stripe signature verification, GitHub webhook secrets, Twilio request validation), the application **MUST** implement its own verification at the application layer.
+
+---
+
+## Checking & Enabling Webhooks
+
+Use the `mcp__major-platform__get_app_status` tool to check the current app status, including `webhooksEnabled`.
+
+If webhooks are not enabled, instruct the user to enable them from the **Major dashboard → App Settings → Webhook Access** toggle.
+
+**Note:** If the app is already public (`isPublic: true`), webhook access is not needed — all unauthenticated traffic is already allowed.
+
+---
+
+## Implementing Webhook Endpoints
+
+Create your webhook routes under the `/api/webhook/` path. Only routes matching this pattern will bypass authentication when webhook access is enabled.
+
+```typescript
+// app/api/webhook/stripe/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
+
+export async function POST(request: NextRequest) {
+	const body = await request.text();
+	const signature = request.headers.get("stripe-signature")!;
+
+	// CRITICAL: Verify the webhook signature at the application layer
+	let event: Stripe.Event;
+	try {
+		event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
+	} catch (err) {
+		return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+	}
+
+	// Handle the verified event
+	switch (event.type) {
+		case "checkout.session.completed":
+			// Process the event
+			break;
+	}
+
+	return NextResponse.json({ received: true });
+}
+```
+
+---
+
+## Tips
+
+- **Deployed apps only** — Webhook bypass only applies to deployed applications, not coding sessions
+- **Route pattern** — Only `/api/webhook/*` routes are bypassed. All other routes still require authentication
+- **Always verify signatures** — Since Major does not authenticate webhook requests, you MUST verify request authenticity yourself using provider-specific mechanisms (signatures, shared secrets, etc.)
+- **Public apps** — If the app is already public, the webhook toggle is irrelevant since all routes are already accessible without authentication
+- **Environment variables** — Store webhook secrets (e.g., `STRIPE_WEBHOOK_SECRET`, `GITHUB_WEBHOOK_SECRET`) as environment variables in the Major dashboard


### PR DESCRIPTION
## Summary
- Move 27 transferable skills from ai-coder to the CLI plugin (22 resource skills, memory, data-table, crons, authn, webhooks)
- Fix `.gitignore` — `/major` instead of `major` to avoid ignoring `plugins/major/`
- These skills are now available to local Claude Code users via the plugin and will be pulled into ai-coder at Docker build time

## Test plan
- [ ] Install plugin locally and verify all new skills are discoverable
- [ ] Verify resource skills match MCP tools available via `major-resources`

🤖 Generated with [Claude Code](https://claude.com/claude-code)