### PR TITLE
feat: add description field instruction to resource skills

### DIFF
--- a/plugins/shared/skills/resources_bigquery/SKILL.md
+++ b/plugins/shared/skills/resources_bigquery/SKILL.md
@@ -9,6 +9,8 @@ description: Implements BigQuery dataset exploration, SQL queries, and table ope
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_cosmosdb/SKILL.md
+++ b/plugins/shared/skills/resources_cosmosdb/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Azure CosmosDB container queries, CRUD, and patch operat
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_custom-api/SKILL.md
+++ b/plugins/shared/skills/resources_custom-api/SKILL.md
@@ -9,6 +9,8 @@ description: Implements custom REST API HTTP requests with automatic auth header
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_dynamodb/SKILL.md
+++ b/plugins/shared/skills/resources_dynamodb/SKILL.md
@@ -9,6 +9,8 @@ description: Implements DynamoDB queries, scans, and CRUD operations using gener
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_google-analytics/SKILL.md
+++ b/plugins/shared/skills/resources_google-analytics/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Google Analytics (GA4) reporting, metadata exploration, 
 
 **Security**: Never connect directly to APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_googlesheets/SKILL.md
+++ b/plugins/shared/skills/resources_googlesheets/SKILL.md
@@ -33,6 +33,8 @@ If you call a Google Sheets MCP tool and get an error indicating no spreadsheet 
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_graphql/SKILL.md
+++ b/plugins/shared/skills/resources_graphql/SKILL.md
@@ -9,6 +9,8 @@ description: Executes GraphQL queries and mutations against a configured endpoin
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_hubspot/SKILL.md
+++ b/plugins/shared/skills/resources_hubspot/SKILL.md
@@ -9,6 +9,8 @@ description: Implements HubSpot CRM data access for contacts, companies, and dea
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_lambda/SKILL.md
+++ b/plugins/shared/skills/resources_lambda/SKILL.md
@@ -9,6 +9,8 @@ description: Implements AWS Lambda function invocation and management using gene
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_majorauth/SKILL.md
+++ b/plugins/shared/skills/resources_majorauth/SKILL.md
@@ -7,6 +7,8 @@ description: Share or revoke application access for users by email. Use whenever
 
 ## Common: Interacting with Resources
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "Share access with user", "Revoke user access"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_mssql/SKILL.md
+++ b/plugins/shared/skills/resources_mssql/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Microsoft SQL Server connections, queries, and schema ex
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_neo4j/SKILL.md
+++ b/plugins/shared/skills/resources_neo4j/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Neo4j Cypher queries, graph traversal, and node/relation
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_outreach/SKILL.md
+++ b/plugins/shared/skills/resources_outreach/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Outreach prospect and sequence management using generate
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_postgresql/SKILL.md
+++ b/plugins/shared/skills/resources_postgresql/SKILL.md
@@ -9,6 +9,8 @@ description: Implements PostgreSQL connections, SQL queries, and migration patte
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_quickbooks/SKILL.md
+++ b/plugins/shared/skills/resources_quickbooks/SKILL.md
@@ -9,6 +9,8 @@ description: Implements QuickBooks Online accounting data access for customers, 
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_s3/SKILL.md
+++ b/plugins/shared/skills/resources_s3/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Amazon S3 object operations, presigned URLs, and file up
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_salesforce/SKILL.md
+++ b/plugins/shared/skills/resources_salesforce/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Salesforce SOQL queries, sObject CRUD, and metadata expl
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_slack/SKILL.md
+++ b/plugins/shared/skills/resources_slack/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Slack messaging, channel operations, and Web API calls u
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.

--- a/plugins/shared/skills/resources_snowflake/SKILL.md
+++ b/plugins/shared/skills/resources_snowflake/SKILL.md
@@ -9,6 +9,8 @@ description: Implements Snowflake warehouse queries, schema exploration, and dat
 
 **Security**: Never connect directly to databases/APIs. Never use credentials in code. Always use generated clients or MCP tools.
 
+**Description field:** Always include a short `description` (~5 words) when calling any resource MCP tool, explaining what the operation does (e.g. "List all user accounts", "Check table schema"). This is displayed to the user in the chat UI.
+
 **Two ways to interact with resources:**
 
 1. **MCP tools** (direct, no code needed): Tools follow the pattern `mcp__resources__<resourcetype>_<toolname>`. Use `mcp__resources__list_resources` to discover available resources and their IDs.


### PR DESCRIPTION
## Summary

- Adds a `**Description field:**` instruction to all 17 resource SKILL.md files (excluding list-resources, managed-database, ai-proxy which don't have resource tool args)
- Instructs the AI coder to always include a short `description` (~5 words) when calling any resource MCP tool
- The description is displayed to the user in the chat UI tool card header (e.g., "Query PostgreSQL: List all user accounts")

## Test plan

- [ ] Verify AI coder includes description when calling resource MCP tools
- [ ] Verify description appears in chat UI tool card headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)