### PR TITLE
feat: add resource connect command and simplify CLI surface

### DIFF
--- a/clients/api/structs.go
+++ b/clients/api/structs.go
@@ -100,6 +100,7 @@ type ResourceItem struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Type        string `json:"type"`
+	AuthMode    string `json:"authMode"`
 }
 
 // GetApplicationResourcesResponse represents the response from GET /applications/:applicationId/resources

--- a/cmd/resource/connect.go
+++ b/cmd/resource/connect.go
@@ -1,0 +1,85 @@
+package resource
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/major-technology/cli/errors"
+	"github.com/major-technology/cli/middleware"
+	"github.com/major-technology/cli/singletons"
+	"github.com/major-technology/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var environmentFlag string
+
+var connectCmd = &cobra.Command{
+	Use:   "connect <resourceId> [resourceId...]",
+	Short: "Open the browser to connect your OAuth accounts for per-user resources",
+	Long: `Opens the /connect page in your browser so you can authenticate with
+per-user OAuth resources. Resource IDs can be found via the web UI connectors page
+or from the list_resources MCP tool.
+
+If --environment is not provided, the app's current environment is used
+(resolved from the git remote in the current directory).`,
+	Args: cobra.MinimumNArgs(1),
+	PreRunE: middleware.Compose(
+		middleware.CheckLogin,
+	),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runConnect(cmd, args)
+	},
+}
+
+func init() {
+	connectCmd.Flags().StringVar(&environmentFlag, "environment", "", "Environment ID (defaults to app's current environment)")
+}
+
+func runConnect(cmd *cobra.Command, resourceIds []string) error {
+	cfg := singletons.GetConfig()
+	if cfg == nil {
+		return fmt.Errorf("configuration not initialized")
+	}
+
+	envID := environmentFlag
+
+	if envID == "" {
+		// Resolve environment from app context
+		appInfo, err := utils.GetApplicationInfo("")
+		if err != nil {
+			return &errors.CLIError{
+				Title:      "Could not resolve environment",
+				Suggestion: "Use --environment <envId> or run this command from an app directory with a git remote.",
+				Err:        err,
+			}
+		}
+
+		apiClient := singletons.GetAPIClient()
+
+		envResp, err := apiClient.GetApplicationEnvironment(appInfo.ApplicationID)
+		if err != nil {
+			return errors.WrapError("failed to get application environment", err)
+		}
+
+		if envResp.EnvironmentID == nil {
+			return &errors.CLIError{
+				Title:      "No environment set",
+				Suggestion: "Use --environment <envId> or run 'major resource env' to choose one.",
+			}
+		}
+
+		envID = *envResp.EnvironmentID
+	}
+
+	// Build the connect URL
+	resources := strings.Join(resourceIds, ",")
+	connectURL := fmt.Sprintf("%s/connect?resources=%s&environmentId=%s", cfg.FrontendURI, resources, envID)
+
+	if err := utils.OpenBrowser(connectURL); err != nil {
+		cmd.Printf("Failed to open browser automatically. Please visit:\n%s\n", connectURL)
+		return nil
+	}
+
+	cmd.Printf("Opening connect page in your browser:\n%s\n", connectURL)
+	return nil
+}

--- a/cmd/resource/connect.go
+++ b/cmd/resource/connect.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/major-technology/cli/errors"
 	"github.com/major-technology/cli/middleware"
 	"github.com/major-technology/cli/singletons"
 	"github.com/major-technology/cli/utils"
@@ -20,8 +19,9 @@ var connectCmd = &cobra.Command{
 per-user OAuth resources. Resource IDs can be found via the web UI connectors page
 or from the list_resources MCP tool.
 
-If --environment is not provided, the app's current environment is used
-(resolved from the git remote in the current directory).`,
+If --environment is not provided, the environment is auto-resolved from
+the app's git remote. If that also fails, the connect page will use
+the org's default environment.`,
 	Args: cobra.MinimumNArgs(1),
 	PreRunE: middleware.Compose(
 		middleware.CheckLogin,
@@ -41,39 +41,28 @@ func runConnect(cmd *cobra.Command, resourceIds []string) error {
 		return fmt.Errorf("configuration not initialized")
 	}
 
+	// Build the connect URL
+	resources := strings.Join(resourceIds, ",")
+	connectURL := fmt.Sprintf("%s/connect?resources=%s", cfg.FrontendURI, resources)
+
+	// Append environment if explicitly provided or resolvable from app context
 	envID := environmentFlag
 
 	if envID == "" {
-		// Resolve environment from app context
 		appInfo, err := utils.GetApplicationInfo("")
-		if err != nil {
-			return &errors.CLIError{
-				Title:      "Could not resolve environment",
-				Suggestion: "Use --environment <envId> or run this command from an app directory with a git remote.",
-				Err:        err,
+		if err == nil {
+			apiClient := singletons.GetAPIClient()
+
+			envResp, err := apiClient.GetApplicationEnvironment(appInfo.ApplicationID)
+			if err == nil && envResp.EnvironmentID != nil {
+				envID = *envResp.EnvironmentID
 			}
 		}
-
-		apiClient := singletons.GetAPIClient()
-
-		envResp, err := apiClient.GetApplicationEnvironment(appInfo.ApplicationID)
-		if err != nil {
-			return errors.WrapError("failed to get application environment", err)
-		}
-
-		if envResp.EnvironmentID == nil {
-			return &errors.CLIError{
-				Title:      "No environment set",
-				Suggestion: "Use --environment <envId> or run 'major resource env' to choose one.",
-			}
-		}
-
-		envID = *envResp.EnvironmentID
 	}
 
-	// Build the connect URL
-	resources := strings.Join(resourceIds, ",")
-	connectURL := fmt.Sprintf("%s/connect?resources=%s&environmentId=%s", cfg.FrontendURI, resources, envID)
+	if envID != "" {
+		connectURL += fmt.Sprintf("&environmentId=%s", envID)
+	}
 
 	if err := utils.OpenBrowser(connectURL); err != nil {
 		cmd.Printf("Failed to open browser automatically. Please visit:\n%s\n", connectURL)

--- a/cmd/resource/resource.go
+++ b/cmd/resource/resource.go
@@ -25,4 +25,5 @@ func init() {
 	Cmd.AddCommand(listCmd)
 	Cmd.AddCommand(addCmd)
 	Cmd.AddCommand(removeCmd)
+	Cmd.AddCommand(connectCmd)
 }

--- a/plugins/shared/skills/resources_googlecalendar/SKILL.md
+++ b/plugins/shared/skills/resources_googlecalendar/SKILL.md
@@ -5,14 +5,16 @@ description: Implements Google Calendar event management and scheduling using ge
 
 # Major Platform Resource: Google Calendar
 
-## Setting Up a Google Calendar Connector
+## Per-User OAuth (required before use)
 
-Google Calendar requires OAuth authentication before use.
+Google Calendar uses per-user OAuth — each user must connect their own Google account before any tools will work (`requiresUserOAuth: true` in `list_resources`).
 
-### When the user asks you to set up Google Calendar or connect their calendar:
+**Before calling any Google Calendar tools**, check if the `mcp__user-oauth-setup__setup-user-oauth` tool is available:
 
-1. Call `mcp__resource-setup__request-resource-setup` with `subtype: "googlecalendar"` — this prompts the user to authenticate with Google
-2. Once setup completes, the resource is ready to use
+- **If available** (web ai-coder): Call `setup-user-oauth` with the resource ID. It will prompt the user to connect via a popup.
+- **If not available** (CLI): Run `major resource connect <resourceId>` via the Bash tool — this opens the user's browser to complete OAuth. Then ask the user to confirm they've connected before retrying the resource tools.
+
+Do NOT attempt to call Google Calendar tools without completing this step — the calls will fail.
 
 ---
 
@@ -87,13 +89,3 @@ const createResult = await googleCalendarClient.invoke("POST", "calendars/primar
 
 **Docs**: [Google Calendar API Reference](https://developers.google.com/calendar/api/v3/reference)
 
----
-
-## Per-User OAuth
-
-Google Calendar uses per-user OAuth — each user must connect their own Google account (`requiresUserOAuth: true` in `list_resources`). Before using Google Calendar tools:
-
-1. Call `setup-user-oauth` with the resource ID
-2. If credentials are missing, present the user with the connect URL
-3. **CLI users:** Tell them to run `major resource connect <resourceId> --environment <envId>`
-4. Wait for the user to confirm they've connected, then retry the resource tools

--- a/plugins/shared/skills/resources_googlecalendar/SKILL.md
+++ b/plugins/shared/skills/resources_googlecalendar/SKILL.md
@@ -86,3 +86,14 @@ const createResult = await googleCalendarClient.invoke("POST", "calendars/primar
 - **Scope presets**: The resource may be configured as "readonly" (can only read) or "readwrite" (can read and create/modify events). Write operations will fail with 403 if the resource is readonly.
 
 **Docs**: [Google Calendar API Reference](https://developers.google.com/calendar/api/v3/reference)
+
+---
+
+## Per-User OAuth
+
+Google Calendar uses per-user OAuth — each user must connect their own Google account (`requiresUserOAuth: true` in `list_resources`). Before using Google Calendar tools:
+
+1. Call `setup-user-oauth` with the resource ID
+2. If credentials are missing, present the user with the connect URL
+3. **CLI users:** Tell them to run `major resource connect <resourceId> --environment <envId>`
+4. Wait for the user to confirm they've connected, then retry the resource tools

--- a/plugins/shared/skills/resources_list-resources/SKILL.md
+++ b/plugins/shared/skills/resources_list-resources/SKILL.md
@@ -29,3 +29,14 @@ For each resource you plan to use:
    The agent will download the file, read it, and return a summary plus the local file path.
 4. If the context document contains schema or API information, use it directly — do not make redundant queries (e.g. do not run `\d` table commands if the schema is already in the context doc)
 5. Tell the user which context documents you read and what you learned, so they know their context is being used
+
+## Step 3: Handle per-user OAuth resources
+
+Some resources require each user to connect their own account (`requiresUserOAuth: true` in the `list_resources` response). **You must handle this before attempting to use those resources.**
+
+Check if the `mcp__user-oauth-setup__setup-user-oauth` tool is available:
+
+- **If available** (web ai-coder): Call `setup-user-oauth` with the resource ID. It will prompt the user to connect via a popup and block until complete.
+- **If not available** (CLI): Run `major resource connect <resourceId>` via the Bash tool — this opens the user's browser to complete OAuth. Then ask the user to confirm they've connected before retrying the resource tools.
+
+Do NOT attempt to call resource tools for a `requiresUserOAuth: true` resource without completing this step first — the calls will fail with an authentication error.


### PR DESCRIPTION
## Summary

- Adds `major resource connect <resourceId> [resourceId...]` command for per-user OAuth authentication via browser
- Removes machine-oriented subcommands that are now handled via web UI or MCP tools: `resource list`, `resource add`, `resource remove`, `resource env-list`, `app deploy-status`
- Removes non-interactive flags (`--json`, `--id`, `--no-wait`) from `org list`, `org select`, `resource env`, `app info`, and `app deploy`
- Simplifies `app info` to only display the application ID
- Simplifies `app start` by removing the behind-remote check
- Updates all plugin skill docs and troubleshooting guides to reflect the reduced CLI surface
- Adds `AuthMode` field to `ResourceItem` struct and per-user OAuth handling to Google Calendar and list-resources skills

## Changes

| Area | What |
|------|------|
| `cmd/resource/connect.go` | New `connect` subcommand — opens `/connect` page in browser with resource IDs and optional environment |
| `cmd/resource/resource.go` | Register `connectCmd`, remove `listCmd`, `addCmd`, `removeCmd`, `envListCmd` |
| `cmd/resource/{list,add,remove,env_list}.go` | Deleted |
| `cmd/resource/env.go` | Remove `--id` flag (interactive only now) |
| `cmd/app/deploy.go` | Remove `--no-wait` flag and non-TTY simple polling fallback |
| `cmd/app/deploy_status.go` | Deleted |
| `cmd/app/info.go` | Simplified to only print application ID; remove `--json` flag and API call |
| `cmd/app/start.go` | Remove `IsBehindRemote` check |
| `cmd/org/list.go` | Remove `--json` flag |
| `cmd/org/select.go` | Remove `--id` flag (interactive only now) |
| `clients/api/client.go` | Remove `GetApplicationInfo` method |
| `clients/api/structs.go` | Add `AuthMode` to `ResourceItem`; remove `GetApplicationInfoResponse` |
| `clients/git/client.go` | Remove `IsBehindRemote` function |
| `utils/resources.go` | Inline `ResolveResourceItems` into caller; unexport `detectFramework` |
| `plugins/major/skills/major/` | Update SKILL.md and all docs to reflect removed commands/flags |
| `plugins/shared/skills/resources_googlecalendar/` | Add per-user OAuth flow using `resource connect` |
| `plugins/shared/skills/resources_list-resources/` | Add Step 3 for per-user OAuth handling |

## Context

Companion to major-technology/mono-builder#1014. This slims down the CLI to its interactive-first surface — commands that were added for programmatic/AI use (`resource list`, `resource add --id`, `org select --id`, `deploy-status`, etc.) are removed in favor of MCP tools and the web UI. The new `resource connect` command fills the gap for per-user OAuth flows in CLI environments.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go run main.go resource connect --help` shows correct usage and flags
- [ ] Manual: verify browser opens to correct `/connect` URL with resource IDs and environment ID
- [ ] Verify removed subcommands are no longer available (`resource list`, `resource add`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)