### PR TITLE
feat: add major vars commands for managing env variables

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "major",
       "source": "./plugins/major",
       "description": "Use the Major platform agentically via Claude Code",
-      "version": "1.0.6"
+      "version": "1.0.7"
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: rerelease release dev-install dev-restore
+.PHONY: rerelease release dev-install dev-install-local dev-restore
 
 # Build and install locally for development
 dev-install:
@@ -9,7 +9,24 @@ dev-install:
 	@echo "Installing development build..."
 	@cp major ~/.major/bin/major
 	@rm major
+	@codesign --force --sign - ~/.major/bin/major 2>/dev/null || true
+	@mkdir -p ~/.major
+	@printf "configs/prod.json" > ~/.major/env
 	@echo "Done! Run 'major --version' to verify."
+
+# Build and install locally with local.json config (for testing against local API)
+dev-install-local:
+	@echo "Building CLI with LOCAL config..."
+	go build -ldflags "-X 'github.com/major-technology/cli/cmd.configFile=configs/local.json'" -o major .
+	@echo "Backing up current CLI..."
+	@cp ~/.major/bin/major ~/.major/bin/major.backup 2>/dev/null || true
+	@echo "Installing development build..."
+	@cp major ~/.major/bin/major
+	@rm major
+	@codesign --force --sign - ~/.major/bin/major 2>/dev/null || true
+	@mkdir -p ~/.major
+	@printf "configs/local.json" > ~/.major/env
+	@echo "Done! major CLI now uses configs/local.json"
 
 # Restore original CLI from backup
 dev-restore:

--- a/clients/api/client.go
+++ b/clients/api/client.go
@@ -431,7 +431,7 @@ func (c *Client) GetApplicationForLink(applicationID string) (*GetApplicationFor
 
 // GetEnvVariables retrieves all env variables for an application, including per-environment values
 func (c *Client) GetEnvVariables(applicationID string) (*GetEnvVariablesResponse, error) {
-	path := fmt.Sprintf("/cli/application/%s/env-variables", applicationID)
+	path := fmt.Sprintf("/application/%s/env-variables", applicationID)
 	var resp GetEnvVariablesResponse
 	if err := c.doRequest("GET", path, nil, &resp); err != nil {
 		return nil, err
@@ -441,7 +441,7 @@ func (c *Client) GetEnvVariables(applicationID string) (*GetEnvVariablesResponse
 
 // SetEnvVariable creates or updates a single env variable's value for a specific environment
 func (c *Client) SetEnvVariable(applicationID, key, environmentID, value string) (*SetEnvVariableResponse, error) {
-	path := fmt.Sprintf("/cli/application/%s/env-variables/set", applicationID)
+	path := fmt.Sprintf("/application/%s/env-variables/set", applicationID)
 	req := SetEnvVariableRequest{
 		Key:           key,
 		EnvironmentID: environmentID,
@@ -458,7 +458,7 @@ func (c *Client) SetEnvVariable(applicationID, key, environmentID, value string)
 // Pass environmentID for single-env removal (and allEnvironments=false), or allEnvironments=true
 // (with empty environmentID) to remove the entire row across all environments.
 func (c *Client) DeleteEnvVariableByKey(applicationID, key, environmentID string, allEnvironments bool) (*DeleteEnvVariableResponse, error) {
-	path := fmt.Sprintf("/cli/application/%s/env-variables/by-key/%s", applicationID, url.PathEscape(key))
+	path := fmt.Sprintf("/application/%s/env-variables/by-key/%s", applicationID, url.PathEscape(key))
 	query := url.Values{}
 	if allEnvironments {
 		query.Set("allEnvironments", "true")

--- a/clients/api/client.go
+++ b/clients/api/client.go
@@ -68,7 +68,9 @@ func (c *Client) doRequestInternal(method, path string, body interface{}, respon
 		return clierrors.WrapError("failed to create request", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}

--- a/clients/api/client.go
+++ b/clients/api/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	mjrToken "github.com/major-technology/cli/clients/token"
@@ -421,6 +422,54 @@ func (c *Client) GetApplicationForLink(applicationID string) (*GetApplicationFor
 	path := fmt.Sprintf("/application/%s/link-info", applicationID)
 	err := c.doRequest("GET", path, nil, &resp)
 	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// --- Env variable endpoints ---
+
+// GetEnvVariables retrieves all env variables for an application, including per-environment values
+func (c *Client) GetEnvVariables(applicationID string) (*GetEnvVariablesResponse, error) {
+	path := fmt.Sprintf("/cli/application/%s/env-variables", applicationID)
+	var resp GetEnvVariablesResponse
+	if err := c.doRequest("GET", path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SetEnvVariable creates or updates a single env variable's value for a specific environment
+func (c *Client) SetEnvVariable(applicationID, key, environmentID, value string) (*SetEnvVariableResponse, error) {
+	path := fmt.Sprintf("/cli/application/%s/env-variables/set", applicationID)
+	req := SetEnvVariableRequest{
+		Key:           key,
+		EnvironmentID: environmentID,
+		Value:         value,
+	}
+	var resp SetEnvVariableResponse
+	if err := c.doRequest("POST", path, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteEnvVariableByKey deletes an env variable's value for a single environment, or the entire row.
+// Pass environmentID for single-env removal (and allEnvironments=false), or allEnvironments=true
+// (with empty environmentID) to remove the entire row across all environments.
+func (c *Client) DeleteEnvVariableByKey(applicationID, key, environmentID string, allEnvironments bool) (*DeleteEnvVariableResponse, error) {
+	path := fmt.Sprintf("/cli/application/%s/env-variables/by-key/%s", applicationID, url.PathEscape(key))
+	query := url.Values{}
+	if allEnvironments {
+		query.Set("allEnvironments", "true")
+	} else if environmentID != "" {
+		query.Set("environmentId", environmentID)
+	}
+	if encoded := query.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	var resp DeleteEnvVariableResponse
+	if err := c.doRequest("DELETE", path, nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/clients/api/structs.go
+++ b/clients/api/structs.go
@@ -234,9 +234,57 @@ type GetDemoResourceResponse struct {
 
 // EnvironmentItem represents a single environment
 type EnvironmentItem struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	IsDefault bool   `json:"isDefault"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	IsDefault      bool   `json:"isDefault"`
+	IsDefaultBuild bool   `json:"isDefaultBuild"`
+}
+
+// --- Env variable structs ---
+
+// EnvVariableValue represents a per-environment value for an env variable
+type EnvVariableValue struct {
+	EnvironmentID string `json:"environmentId"`
+	Value         string `json:"value"`
+}
+
+// EnvVariable represents an env variable row as returned by the server
+type EnvVariable struct {
+	ID             string             `json:"id"`
+	OrganizationID string             `json:"organizationId"`
+	ApplicationID  string             `json:"applicationId"`
+	Key            string             `json:"key"`
+	Values         []EnvVariableValue `json:"values"`
+	CreatedAt      string             `json:"createdAt,omitempty"`
+	UpdatedAt      string             `json:"updatedAt,omitempty"`
+}
+
+// GetEnvVariablesResponse represents the response from GET /cli/application/:applicationId/env-variables
+type GetEnvVariablesResponse struct {
+	Error        *AppErrorDetail `json:"error,omitempty"`
+	EnvVariables []EnvVariable   `json:"envVariables,omitempty"`
+}
+
+// SetEnvVariableRequest represents the request body for POST /cli/application/:applicationId/env-variables/set
+type SetEnvVariableRequest struct {
+	Key           string `json:"key"`
+	EnvironmentID string `json:"environmentId"`
+	Value         string `json:"value"`
+}
+
+// SetEnvVariableResponse represents the response from POST /cli/application/:applicationId/env-variables/set
+type SetEnvVariableResponse struct {
+	Error   *AppErrorDetail `json:"error,omitempty"`
+	ID      string          `json:"id,omitempty"`
+	Key     string          `json:"key,omitempty"`
+	Created bool            `json:"created,omitempty"`
+}
+
+// DeleteEnvVariableResponse represents the response from DELETE /cli/application/:applicationId/env-variables/by-key/:key
+type DeleteEnvVariableResponse struct {
+	Error      *AppErrorDetail `json:"error,omitempty"`
+	Deleted    bool            `json:"deleted"`
+	RemovedRow bool            `json:"removedRow"`
 }
 
 // GetApplicationEnvironmentResponse represents the response from GET /application/:applicationId/environment

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/major-technology/cli/cmd/org"
 	"github.com/major-technology/cli/cmd/resource"
 	"github.com/major-technology/cli/cmd/user"
+	"github.com/major-technology/cli/cmd/vars"
 	clierrors "github.com/major-technology/cli/errors"
 	"github.com/major-technology/cli/middleware"
 	"github.com/major-technology/cli/singletons"
@@ -110,6 +111,9 @@ func init() {
 
 	resource.Cmd.GroupID = "main"
 	rootCmd.AddCommand(resource.Cmd)
+
+	vars.Cmd.GroupID = "main"
+	rootCmd.AddCommand(vars.Cmd)
 
 	rootCmd.AddCommand(mcp.Cmd)
 

--- a/cmd/vars/get.go
+++ b/cmd/vars/get.go
@@ -1,0 +1,89 @@
+package vars
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/major-technology/cli/errors"
+	"github.com/major-technology/cli/singletons"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagGetEnv  string
+	flagGetJSON bool
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get <KEY>",
+	Short: "Print a single environment variable's value",
+	Long: `Print the value of a single environment variable for the selected environment.
+
+The raw value is written to stdout, with no prefix, suitable for shell use:
+  export DATABASE_URL=$(major vars get DATABASE_URL)
+
+Exits non-zero if the key does not exist or has no value in the target environment.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGet(cmd, args[0])
+	},
+}
+
+func init() {
+	getCmd.Flags().StringVar(&flagGetEnv, "env", "", "Target environment name (defaults to your current environment)")
+	getCmd.Flags().BoolVar(&flagGetJSON, "json", false, "Output in JSON format: {key, value, environment}")
+}
+
+type getJSONOutput struct {
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	Environment string `json:"environment"`
+}
+
+func runGet(cmd *cobra.Command, key string) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
+
+	appID, err := getAppID()
+	if err != nil {
+		return err
+	}
+
+	env, err := resolveEnvironment(appID, flagGetEnv)
+	if err != nil {
+		return err
+	}
+
+	apiClient := singletons.GetAPIClient()
+	resp, err := apiClient.GetEnvVariables(appID)
+	if err != nil {
+		return errors.WrapError("failed to get env variables", err)
+	}
+
+	for _, v := range resp.EnvVariables {
+		if v.Key != key {
+			continue
+		}
+		value, ok := findValueForEnv(v.Values, env.ID)
+		if !ok {
+			return &errors.CLIError{
+				Title: fmt.Sprintf("%s has no value in %q environment", key, env.Name),
+			}
+		}
+		if flagGetJSON {
+			data, err := json.Marshal(getJSONOutput{Key: key, Value: value, Environment: env.Name})
+			if err != nil {
+				return errors.WrapError("failed to encode JSON", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			return nil
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), value)
+		return nil
+	}
+
+	return &errors.CLIError{
+		Title: fmt.Sprintf("%s is not set", key),
+	}
+}

--- a/cmd/vars/helper.go
+++ b/cmd/vars/helper.go
@@ -1,0 +1,112 @@
+package vars
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/major-technology/cli/clients/api"
+	"github.com/major-technology/cli/errors"
+	"github.com/major-technology/cli/singletons"
+	"github.com/major-technology/cli/utils"
+)
+
+// keyPattern matches a valid env var key: must start with a letter or underscore,
+// followed by any number of letters, digits, or underscores.
+var keyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// validateKey checks that a key is a syntactically valid env var name and
+// is not prefixed with MAJOR_ (reserved for platform-managed vars).
+func validateKey(key string) error {
+	if key == "" {
+		return &errors.CLIError{
+			Title:      "Key is required",
+			Suggestion: "Pass a key name, e.g. DATABASE_URL",
+		}
+	}
+	if !keyPattern.MatchString(key) {
+		return &errors.CLIError{
+			Title:      fmt.Sprintf("Invalid key: %q", key),
+			Suggestion: "Keys must start with a letter or underscore and contain only letters, digits, or underscores.",
+		}
+	}
+	if strings.HasPrefix(key, "MAJOR_") {
+		return &errors.CLIError{
+			Title:      fmt.Sprintf("Reserved key prefix: %q", key),
+			Suggestion: "Keys starting with MAJOR_ are managed by the platform and cannot be set or unset from the CLI.",
+		}
+	}
+	return nil
+}
+
+// resolvedEnv holds the target environment for a command invocation.
+type resolvedEnv struct {
+	ID   string
+	Name string
+}
+
+// resolveEnvironment resolves the target environment for a command.
+// If envFlag is non-empty, it looks up the environment by name (case-insensitive).
+// Otherwise, it falls back to the user's currently-selected environment for the app.
+func resolveEnvironment(applicationID, envFlag string) (*resolvedEnv, error) {
+	apiClient := singletons.GetAPIClient()
+
+	if envFlag != "" {
+		listResp, err := apiClient.ListApplicationEnvironments(applicationID)
+		if err != nil {
+			return nil, errors.WrapError("failed to list environments", err)
+		}
+		lower := strings.ToLower(envFlag)
+		for _, env := range listResp.Environments {
+			if strings.ToLower(env.Name) == lower {
+				return &resolvedEnv{ID: env.ID, Name: env.Name}, nil
+			}
+		}
+		return nil, &errors.CLIError{
+			Title:      fmt.Sprintf("Environment %q not found", envFlag),
+			Suggestion: "Run 'major resource env' to see the environments available for this application.",
+		}
+	}
+
+	envResp, err := apiClient.GetApplicationEnvironment(applicationID)
+	if err != nil {
+		return nil, errors.WrapError("failed to get current environment", err)
+	}
+	if envResp.EnvironmentID == nil || envResp.EnvironmentName == nil {
+		return nil, &errors.CLIError{
+			Title:      "No environment selected",
+			Suggestion: "Run 'major resource env' to select an environment, or pass --env <name>.",
+		}
+	}
+	return &resolvedEnv{ID: *envResp.EnvironmentID, Name: *envResp.EnvironmentName}, nil
+}
+
+// getAppID resolves the application ID for the current working directory.
+func getAppID() (string, error) {
+	info, err := utils.GetApplicationInfo("")
+	if err != nil {
+		return "", errors.WrapError("failed to identify application", err)
+	}
+	return info.ApplicationID, nil
+}
+
+// maskValue returns a masked representation of a value suitable for display.
+// Values of 4 chars or fewer are fully masked; longer values show the first
+// 4 characters followed by 8 bullets.
+func maskValue(value string) string {
+	if len(value) <= 4 {
+		return strings.Repeat("•", len(value))
+	}
+	return value[:4] + strings.Repeat("•", 8)
+}
+
+// findValueForEnv returns the value for a specific environment from a row's values slice,
+// and whether it was found.
+func findValueForEnv(values []api.EnvVariableValue, environmentID string) (string, bool) {
+	for _, v := range values {
+		if v.EnvironmentID == environmentID {
+			return v.Value, true
+		}
+	}
+	return "", false
+}

--- a/cmd/vars/list.go
+++ b/cmd/vars/list.go
@@ -1,0 +1,126 @@
+package vars
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/major-technology/cli/errors"
+	"github.com/major-technology/cli/singletons"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagListEnv        string
+	flagListShowValues bool
+	flagListJSON       bool
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List environment variables for the current environment",
+	Long: `List all environment variables for the selected environment.
+
+By default values are masked. Pass --show-values to reveal them, or --json
+to emit machine-readable output with full values.
+
+Example:
+  major vars list --env staging`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runList(cmd)
+	},
+}
+
+func init() {
+	listCmd.Flags().StringVar(&flagListEnv, "env", "", "Target environment name (defaults to your current environment)")
+	listCmd.Flags().BoolVar(&flagListShowValues, "show-values", false, "Show full values instead of masking them")
+	listCmd.Flags().BoolVar(&flagListJSON, "json", false, "Output in JSON format with full values")
+}
+
+type listJSONEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type listJSONOutput struct {
+	Environment string          `json:"environment"`
+	Variables   []listJSONEntry `json:"variables"`
+}
+
+func runList(cmd *cobra.Command) error {
+	appID, err := getAppID()
+	if err != nil {
+		return err
+	}
+
+	env, err := resolveEnvironment(appID, flagListEnv)
+	if err != nil {
+		return err
+	}
+
+	apiClient := singletons.GetAPIClient()
+	resp, err := apiClient.GetEnvVariables(appID)
+	if err != nil {
+		return errors.WrapError("failed to get env variables", err)
+	}
+
+	// Filter to rows that have a value for the target environment
+	type row struct {
+		Key   string
+		Value string
+	}
+	var rows []row
+	for _, v := range resp.EnvVariables {
+		if value, ok := findValueForEnv(v.Values, env.ID); ok {
+			rows = append(rows, row{Key: v.Key, Value: value})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Key < rows[j].Key })
+
+	if flagListJSON {
+		out := listJSONOutput{
+			Environment: env.Name,
+			Variables:   make([]listJSONEntry, 0, len(rows)),
+		}
+		for _, r := range rows {
+			out.Variables = append(out.Variables, listJSONEntry{Key: r.Key, Value: r.Value})
+		}
+		data, err := json.Marshal(out)
+		if err != nil {
+			return errors.WrapError("failed to encode JSON", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		return nil
+	}
+
+	cmd.Printf("Environment: %s\n\n", env.Name)
+
+	if len(rows) == 0 {
+		cmd.Println("No variables set.")
+		return nil
+	}
+
+	// Compute column width for key
+	maxKey := len("KEY")
+	for _, r := range rows {
+		if len(r.Key) > maxKey {
+			maxKey = len(r.Key)
+		}
+	}
+
+	cmd.Printf("%-*s  %s\n", maxKey, "KEY", "VALUE")
+	for _, r := range rows {
+		display := r.Value
+		if !flagListShowValues {
+			display = maskValue(r.Value)
+		}
+		cmd.Printf("%-*s  %s\n", maxKey, r.Key, display)
+	}
+
+	noun := "variables"
+	if len(rows) == 1 {
+		noun = "variable"
+	}
+	cmd.Printf("\n%d %s.\n", len(rows), noun)
+	return nil
+}

--- a/cmd/vars/pull.go
+++ b/cmd/vars/pull.go
@@ -1,0 +1,250 @@
+package vars
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/major-technology/cli/clients/git"
+	"github.com/major-technology/cli/errors"
+	"github.com/major-technology/cli/singletons"
+	"github.com/major-technology/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagPullEnv  string
+	flagPullFile string
+)
+
+var pullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Download environment variables to a local .env file",
+	Long: `Download all environment variables for the selected environment into a
+local dotenv file.
+
+Writes both user-defined variables and platform-managed MAJOR_* system
+variables needed for local development. Overwrites the target file.
+
+If the target file is inside a git repository and is not yet ignored,
+appends it to the repo's .gitignore.
+
+Example:
+  major vars pull --env staging --file .env.staging`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runPull(cmd)
+	},
+}
+
+func init() {
+	pullCmd.Flags().StringVar(&flagPullEnv, "env", "", "Target environment name (defaults to your current environment)")
+	pullCmd.Flags().StringVar(&flagPullFile, "file", ".env", "Path to write the dotenv file")
+}
+
+func runPull(cmd *cobra.Command) error {
+	info, err := utils.GetApplicationInfo("")
+	if err != nil {
+		return errors.WrapError("failed to identify application", err)
+	}
+
+	apiClient := singletons.GetAPIClient()
+
+	// Resolve target environment (flag takes precedence over stored choice).
+	env, err := resolveEnvironment(info.ApplicationID, flagPullEnv)
+	if err != nil {
+		return err
+	}
+
+	// If the user passed --env and it differs from their stored choice, switch
+	// their stored choice to the requested environment before fetching. The
+	// POST /application/env endpoint always uses the user's stored choice.
+	if flagPullEnv != "" {
+		currentResp, err := apiClient.GetApplicationEnvironment(info.ApplicationID)
+		if err != nil {
+			return errors.WrapError("failed to get current environment", err)
+		}
+		if currentResp.EnvironmentID == nil || *currentResp.EnvironmentID != env.ID {
+			cmd.Printf("Setting your active environment to %q...\n", env.Name)
+			if _, err := apiClient.SetApplicationEnvironment(info.ApplicationID, env.ID); err != nil {
+				return errors.WrapError("failed to switch environment", err)
+			}
+		}
+	}
+
+	envVars, err := apiClient.GetApplicationEnv(info.OrganizationID, info.ApplicationID)
+	if err != nil {
+		return errors.WrapError("failed to fetch environment variables", err)
+	}
+
+	// Sort keys: user-defined first (alphabetical), then MAJOR_* (alphabetical).
+	userKeys := make([]string, 0, len(envVars))
+	majorKeys := make([]string, 0)
+	for k := range envVars {
+		if strings.HasPrefix(k, "MAJOR_") {
+			majorKeys = append(majorKeys, k)
+		} else {
+			userKeys = append(userKeys, k)
+		}
+	}
+	sort.Strings(userKeys)
+	sort.Strings(majorKeys)
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# Pulled from Major %q environment at %s\n", env.Name, time.Now().UTC().Format(time.RFC3339))
+	builder.WriteString("# Do not edit MAJOR_* variables - they are managed by the platform\n\n")
+	for _, k := range userKeys {
+		builder.WriteString(formatDotenvLine(k, envVars[k]))
+	}
+	if len(majorKeys) > 0 && len(userKeys) > 0 {
+		builder.WriteString("\n")
+	}
+	for _, k := range majorKeys {
+		builder.WriteString(formatDotenvLine(k, envVars[k]))
+	}
+
+	targetPath, err := filepath.Abs(flagPullFile)
+	if err != nil {
+		return errors.WrapError("failed to resolve target file path", err)
+	}
+
+	if err := os.WriteFile(targetPath, []byte(builder.String()), 0600); err != nil {
+		return errors.WrapError("failed to write dotenv file", err)
+	}
+
+	if err := ensureGitignore(cmd, targetPath); err != nil {
+		// Non-fatal - warn but do not fail the pull.
+		cmd.Printf("Warning: failed to update .gitignore: %v\n", err)
+	}
+
+	cmd.Printf("Environment: %s\n", env.Name)
+	cmd.Printf("Pulled %d variables to %s.\n", len(envVars), flagPullFile)
+	return nil
+}
+
+// formatDotenvLine returns a single KEY=value line with appropriate quoting.
+func formatDotenvLine(key, value string) string {
+	return fmt.Sprintf("%s=%s\n", key, quoteDotenvValue(value))
+}
+
+// quoteDotenvValue returns a dotenv-safe representation of value.
+// Values containing whitespace or shell/special characters are double-quoted
+// with embedded newlines, quotes, backslashes, and dollar signs escaped.
+func quoteDotenvValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	needsQuoting := false
+	for _, r := range value {
+		switch r {
+		case ' ', '\t', '\n', '\r', '"', '\'', '`', '$', '#', '\\':
+			needsQuoting = true
+		}
+		if needsQuoting {
+			break
+		}
+	}
+	if !needsQuoting {
+		return value
+	}
+
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '$':
+			b.WriteString(`\$`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// ensureGitignore appends the target file to .gitignore in the repo root if
+// the file is inside a git repository and is not already ignored.
+func ensureGitignore(cmd *cobra.Command, targetPath string) error {
+	repoRoot, err := git.GetRepoRoot()
+	if err != nil {
+		// Not in a git repo - nothing to do.
+		return nil
+	}
+
+	rel, err := filepath.Rel(repoRoot, targetPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		// Target file is outside the repo - nothing to do.
+		return nil
+	}
+
+	gitignorePath := filepath.Join(repoRoot, ".gitignore")
+
+	existing := ""
+	if data, err := os.ReadFile(gitignorePath); err == nil {
+		existing = string(data)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	base := filepath.Base(targetPath)
+	if isIgnored(existing, rel, base) {
+		return nil
+	}
+
+	entry := rel
+	// Normalize to forward slashes for gitignore.
+	entry = filepath.ToSlash(entry)
+
+	var out strings.Builder
+	out.WriteString(existing)
+	if existing != "" && !strings.HasSuffix(existing, "\n") {
+		out.WriteString("\n")
+	}
+	out.WriteString(entry)
+	out.WriteString("\n")
+
+	if err := os.WriteFile(gitignorePath, []byte(out.String()), 0644); err != nil {
+		return err
+	}
+
+	cmd.Printf("Added %s to .gitignore\n", entry)
+	return nil
+}
+
+// isIgnored returns true if the provided .gitignore content already contains
+// an entry that would match the target file (exact match, base name match,
+// or a simple glob prefix match such as ".env*" for ".env").
+func isIgnored(gitignoreContent, relPath, baseName string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(gitignoreContent))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "/")
+		lineSlashed := filepath.ToSlash(line)
+		relSlashed := filepath.ToSlash(relPath)
+		if lineSlashed == relSlashed || lineSlashed == baseName {
+			return true
+		}
+		// Simple prefix-glob support: ".env*" matches ".env" and ".env.local".
+		if strings.HasSuffix(line, "*") {
+			prefix := strings.TrimSuffix(line, "*")
+			if strings.HasPrefix(baseName, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cmd/vars/set.go
+++ b/cmd/vars/set.go
@@ -1,0 +1,66 @@
+package vars
+
+import (
+	"strings"
+
+	"github.com/major-technology/cli/errors"
+	"github.com/major-technology/cli/singletons"
+	"github.com/spf13/cobra"
+)
+
+var flagSetEnv string
+
+var setCmd = &cobra.Command{
+	Use:   "set <KEY>=<VALUE>",
+	Short: "Create or update an environment variable",
+	Long: `Create or update a single environment variable for the selected environment.
+
+Other environments' values are preserved. Values may contain '=' characters;
+only the first '=' in the argument is treated as the separator.
+
+Example:
+  major vars set DATABASE_URL=postgres://localhost/mydb --env staging`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSet(cmd, args[0])
+	},
+}
+
+func init() {
+	setCmd.Flags().StringVar(&flagSetEnv, "env", "", "Target environment name (defaults to your current environment)")
+}
+
+func runSet(cmd *cobra.Command, arg string) error {
+	idx := strings.Index(arg, "=")
+	if idx <= 0 {
+		return &errors.CLIError{
+			Title:      "Invalid argument",
+			Suggestion: "Pass the variable as KEY=VALUE, e.g. major vars set DATABASE_URL=postgres://...",
+		}
+	}
+	key := arg[:idx]
+	value := arg[idx+1:]
+
+	if err := validateKey(key); err != nil {
+		return err
+	}
+
+	appID, err := getAppID()
+	if err != nil {
+		return err
+	}
+
+	env, err := resolveEnvironment(appID, flagSetEnv)
+	if err != nil {
+		return err
+	}
+
+	apiClient := singletons.GetAPIClient()
+	if _, err := apiClient.SetEnvVariable(appID, key, env.ID, value); err != nil {
+		return errors.WrapError("failed to set env variable", err)
+	}
+
+	cmd.Printf("Environment: %s\n", env.Name)
+	cmd.Printf("Set %s.\n", key)
+	return nil
+}

--- a/cmd/vars/unset.go
+++ b/cmd/vars/unset.go
@@ -1,0 +1,109 @@
+package vars
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/major-technology/cli/errors"
+	"github.com/major-technology/cli/singletons"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagUnsetEnv             string
+	flagUnsetAllEnvironments bool
+	flagUnsetYes             bool
+)
+
+var unsetCmd = &cobra.Command{
+	Use:   "unset <KEY>",
+	Short: "Remove an environment variable",
+	Long: `Remove an environment variable.
+
+By default, removes only the value for the target environment, preserving
+values set in other environments. Pass --all-environments to delete the key
+across every environment.
+
+Prompts for confirmation unless --yes is passed.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUnset(cmd, args[0])
+	},
+}
+
+func init() {
+	unsetCmd.Flags().StringVar(&flagUnsetEnv, "env", "", "Target environment name (defaults to your current environment)")
+	unsetCmd.Flags().BoolVar(&flagUnsetAllEnvironments, "all-environments", false, "Remove the key across every environment")
+	unsetCmd.Flags().BoolVarP(&flagUnsetYes, "yes", "y", false, "Skip the confirmation prompt")
+}
+
+func runUnset(cmd *cobra.Command, key string) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
+
+	appID, err := getAppID()
+	if err != nil {
+		return err
+	}
+
+	var envID, envName string
+	if !flagUnsetAllEnvironments {
+		env, err := resolveEnvironment(appID, flagUnsetEnv)
+		if err != nil {
+			return err
+		}
+		envID = env.ID
+		envName = env.Name
+	} else if flagUnsetEnv != "" {
+		return &errors.CLIError{
+			Title:      "Conflicting flags",
+			Suggestion: "--env and --all-environments cannot be used together.",
+		}
+	}
+
+	if !flagUnsetYes {
+		var prompt string
+		if flagUnsetAllEnvironments {
+			prompt = fmt.Sprintf("Remove %s from ALL environments?", key)
+		} else {
+			prompt = fmt.Sprintf("Remove %s from %q environment?", key, envName)
+		}
+		var confirm bool
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewConfirm().Title(prompt).Value(&confirm),
+			),
+		)
+		if err := form.Run(); err != nil {
+			return errors.WrapError("failed to read confirmation", err)
+		}
+		if !confirm {
+			return errors.ErrorOperationCancelled
+		}
+	}
+
+	apiClient := singletons.GetAPIClient()
+	resp, err := apiClient.DeleteEnvVariableByKey(appID, key, envID, flagUnsetAllEnvironments)
+	if err != nil {
+		return errors.WrapError("failed to unset env variable", err)
+	}
+
+	switch {
+	case !resp.Deleted && flagUnsetAllEnvironments:
+		cmd.Printf("%s was not set.\n", key)
+	case !resp.Deleted:
+		cmd.Printf("Environment: %s\n", envName)
+		cmd.Printf("%s was not set in %q.\n", key, envName)
+	case flagUnsetAllEnvironments:
+		cmd.Printf("Removed %s from all environments.\n", key)
+	default:
+		cmd.Printf("Environment: %s\n", envName)
+		if resp.RemovedRow {
+			cmd.Printf("Removed %s (last value, key deleted).\n", key)
+		} else {
+			cmd.Printf("Removed %s.\n", key)
+		}
+	}
+	return nil
+}

--- a/cmd/vars/vars.go
+++ b/cmd/vars/vars.go
@@ -1,0 +1,33 @@
+package vars
+
+import (
+	"github.com/major-technology/cli/middleware"
+	"github.com/major-technology/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+// Cmd represents the vars command
+var Cmd = &cobra.Command{
+	Use:   "vars",
+	Short: "Manage environment variables",
+	Long: `Manage environment variables for the current application.
+
+Variables are scoped per-environment (e.g. development, staging, production).
+Run these commands from inside a linked application directory.`,
+	Args: utils.NoArgs,
+	PersistentPreRunE: middleware.Compose(
+		middleware.CheckLogin,
+	),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.Help()
+		return nil
+	},
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(getCmd)
+	Cmd.AddCommand(setCmd)
+	Cmd.AddCommand(unsetCmd)
+	Cmd.AddCommand(pullCmd)
+}

--- a/plugins/major/skills/major/SKILL.md
+++ b/plugins/major/skills/major/SKILL.md
@@ -28,6 +28,24 @@ Major is a platform for building and deploying Next.js web applications. It crea
 | `major app info --json` | App info as JSON | Direct |
 | `major app configure` | Open app settings in browser | Direct |
 
+### Environment Variable Commands
+
+| Command | Description | Mode |
+|---------|-------------|------|
+| `major vars list` | List env vars for current environment (masked values) | Direct |
+| `major vars list --show-values` | List env vars with full values | Direct |
+| `major vars list --json` | List env vars as JSON (includes full values) | Direct |
+| `major vars get KEY` | Print a single env var's raw value | Direct |
+| `major vars get KEY --json` | Print a single env var as JSON | Direct |
+| `major vars set KEY=VALUE` | Create or update an env var | Direct |
+| `major vars unset KEY` | Remove an env var from current env | Interactive |
+| `major vars unset KEY --yes` | Remove an env var without prompting | Direct |
+| `major vars unset KEY --all-environments --yes` | Remove an env var from all environments | Direct |
+| `major vars pull` | Download env vars to local .env file | Direct |
+| `major vars pull --file .env.staging` | Download to a custom file path | Direct |
+
+All vars commands accept `--env <name>` to target a specific environment (case-insensitive). Without it, they use the user's currently-selected environment.
+
 ### Resource Commands
 
 | Command | Description | Mode |
@@ -102,6 +120,8 @@ Major is a platform for building and deploying Next.js web applications. It crea
 
 6. **Resource management**: Use `major resource list` to see available resources, then `major resource add --id <id>` or `major resource remove --id <id>` to manage them programmatically. Use `major resource env-list --json` to see environments and `major resource env --id <id>` to switch.
 
+8. **Environment variable management**: Use `major vars` commands to manage env vars. Keys must match `^[A-Za-z_][A-Za-z0-9_]*$` and cannot start with `MAJOR_` (reserved for the platform). Always use `--yes` with `major vars unset` to avoid interactive prompts. Use `major vars pull` to sync env vars to a local `.env` file -- it auto-updates `.gitignore`.
+
 7. **Organization selection**: Use `major org list --json` to get org IDs, then `major org select --id <id>` to switch orgs programmatically.
 
 ## Workflow Reference
@@ -110,6 +130,7 @@ For detailed workflows, see the docs below:
 
 - [Getting Started](docs/getting-started.md) -- Install, auth, first app
 - [App Workflows](docs/app-workflows.md) -- Create, clone, start, deploy
+- [Env Variables](docs/env-variables.md) -- Set, list, pull, and manage env vars per environment
 - [Resource Workflows](docs/resource-workflows.md) -- Create, manage, environments
 - [Org Management](docs/org-management.md) -- Organizations and teams
 - [Troubleshooting](docs/troubleshooting.md) -- Common issues and fixes

--- a/plugins/major/skills/major/docs/env-variables.md
+++ b/plugins/major/skills/major/docs/env-variables.md
@@ -124,6 +124,32 @@ MAJOR_JWT_TOKEN="eyJ..."
 
 User-defined keys are sorted alphabetically first, followed by `MAJOR_*` system vars. Values containing special characters (`$`, `#`, spaces, quotes, newlines) are double-quoted with proper escaping.
 
+## Listing Available Environments
+
+Before targeting a specific environment with `--env`, you can see what's available:
+
+```bash
+major resource env-list
+```
+
+Or as JSON (useful for scripting):
+
+```bash
+major resource env-list --json
+```
+
+To switch your active environment interactively:
+
+```bash
+major resource env
+```
+
+Or non-interactively by ID:
+
+```bash
+major resource env --id "<environment-uuid>"
+```
+
 ## Common Patterns
 
 ### Set Up a New Environment Locally

--- a/plugins/major/skills/major/docs/env-variables.md
+++ b/plugins/major/skills/major/docs/env-variables.md
@@ -1,0 +1,148 @@
+# Environment Variable Workflows
+
+Environment variables are scoped per-environment (development, staging, production, etc.). Each app can have different values for the same key in different environments.
+
+## Listing Variables
+
+```bash
+major vars list
+```
+
+Outputs a table with masked values. First line always shows the active environment.
+
+```bash
+major vars list --show-values
+```
+
+Reveals full values.
+
+```bash
+major vars list --json
+```
+
+JSON output with full values -- suitable for scripting.
+
+### Targeting a Specific Environment
+
+All vars commands accept `--env <name>` (case-insensitive):
+
+```bash
+major vars list --env staging
+major vars list --env Production
+```
+
+Without `--env`, commands use the user's currently-selected environment (set via `major resource env`).
+
+## Getting a Single Variable
+
+```bash
+major vars get DATABASE_URL
+```
+
+Prints the raw value to stdout with no prefix -- suitable for shell use:
+
+```bash
+export DB=$(major vars get DATABASE_URL)
+```
+
+Returns exit code 1 if the key does not exist or has no value in the target environment.
+
+```bash
+major vars get DATABASE_URL --json
+```
+
+Wraps the result as `{"key":"...","value":"...","environment":"..."}`.
+
+## Setting Variables
+
+```bash
+major vars set DATABASE_URL=postgres://localhost/mydb
+```
+
+Creates or updates the value for the current environment only. Other environments are not affected.
+
+The argument is split on the **first** `=`, so values can contain `=`:
+
+```bash
+major vars set 'CONNECTION_STRING=host=db;port=5432;user=app'
+```
+
+### Key Rules
+
+- Must match `^[A-Za-z_][A-Za-z0-9_]*$`
+- Cannot start with `MAJOR_` (reserved for platform-managed variables)
+- Setting is idempotent -- running the same command again is a no-op
+
+### Setting for a Specific Environment
+
+```bash
+major vars set DATABASE_URL=postgres://staging-db/app --env staging
+```
+
+## Removing Variables
+
+```bash
+major vars unset SECRET_KEY --yes
+```
+
+Removes the value for the current environment only. The key still exists if other environments have values.
+
+```bash
+major vars unset SECRET_KEY --all-environments --yes
+```
+
+Removes the key across every environment.
+
+Always pass `--yes` in automated/agentic contexts to skip the confirmation prompt.
+
+## Pulling Variables to a Local File
+
+```bash
+major vars pull
+```
+
+Writes all variables (user-defined and platform `MAJOR_*` vars) to `.env` in dotenv format. Automatically adds `.env` to `.gitignore` if it is not already ignored.
+
+```bash
+major vars pull --file .env.staging --env staging
+```
+
+Writes to a custom file and targets a specific environment. Note: `--env` with pull temporarily switches your active environment to fetch the correct values.
+
+### File Format
+
+```bash
+# Pulled from Major "development" environment at 2026-04-13T10:00:00Z
+# Do not edit MAJOR_* variables - they are managed by the platform
+
+DATABASE_URL=postgres://localhost/mydb
+STRIPE_SECRET_KEY="sk_test_abc123"
+
+MAJOR_API_BASE_URL=https://api.major.build
+MAJOR_JWT_TOKEN="eyJ..."
+```
+
+User-defined keys are sorted alphabetically first, followed by `MAJOR_*` system vars. Values containing special characters (`$`, `#`, spaces, quotes, newlines) are double-quoted with proper escaping.
+
+## Common Patterns
+
+### Set Up a New Environment Locally
+
+```bash
+major resource env --id "<staging-env-id>"   # switch to staging
+major vars pull                               # download vars
+major app start                               # start dev server
+```
+
+### Copy a Variable Across Environments
+
+```bash
+VALUE=$(major vars get API_KEY --env production)
+major vars set "API_KEY=$VALUE" --env staging
+```
+
+### Check What's Set Before Deploying
+
+```bash
+major vars list --env production --show-values
+```


### PR DESCRIPTION
## Summary

- Adds `major vars list|get|set|unset|pull` for managing env variables per environment from the terminal
- Fixes a latent API client bug where `Content-Type: application/json` was sent on bodyless requests (Fastify rejects empty JSON bodies)
- Adds `make dev-install-local` to build+install a local-config binary with the matching `~/.major/env` override and macOS ad-hoc signing

## Commands

| Command | Purpose |
|---|---|
| `major vars list` | Table/JSON listing; masks values by default, `--show-values` reveals them |
| `major vars get KEY` | Raw value to stdout, shell-safe (`export X=$(major vars get X)`) |
| `major vars set KEY=VAL` | Splits on first `=`; validates key; blocks `MAJOR_` prefix |
| `major vars unset KEY` | Per-env by default; `--all-environments` wipes the row; confirms unless `--yes` |
| `major vars pull` | Writes sorted dotenv file (user vars first, `MAJOR_*` last), auto-adds to `.gitignore` |

All commands take `--env <name>` (case-insensitive) and fall back to the user's stored environment choice.

## Test plan

- [ ] `major vars list` renders table with masked values and prints `Environment: <name>` header
- [ ] `major vars list --show-values` reveals values
- [ ] `major vars list --json` emits structured output with full values
- [ ] `major vars get EXISTING_KEY` prints raw value with no prefix
- [ ] `major vars get MISSING_KEY` exits non-zero with stderr message
- [ ] `major vars set K=V` creates a new key; re-running with a different value updates it
- [ ] `major vars set K=V --env staging` does not affect other environments
- [ ] `major vars unset K` prompts for confirmation, removes only the target-env value
- [ ] `major vars unset K --all-environments --yes` removes the entire row
- [ ] `major vars unset K` when K doesn't exist reports soft success (exit 0)
- [ ] `major vars pull` writes a `.env` file, adds it to `.gitignore` if inside a repo
- [ ] `major vars pull --env <name>` switches the user's stored env and pulls
- [ ] Key validation rejects invalid names and `MAJOR_*` prefix
- [ ] 401/403/404 responses surface actionable CLI errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)