### PR TITLE
docs(stripe skill): prefer stripe_get over stripe_invoke for reads

### DIFF
--- a/plugins/shared/skills/resources_stripe/SKILL.md
+++ b/plugins/shared/skills/resources_stripe/SKILL.md
@@ -26,14 +26,16 @@ description: Implements Stripe payment API access for customers, payments, subsc
 
 ## MCP Tools
 
-- `mcp__resources__stripe_get` — Make a GET request to any Stripe API endpoint. Args: `resourceId`, `path`, `query?`
+**Tool selection:** For any read-only operation, prefer `stripe_get` (or a specialized `stripe_list_*` / `stripe_get_*` tool) over `stripe_invoke`. Reserve `stripe_invoke` for writes (POST/PUT/DELETE) or endpoints the other tools don't cover.
+
+- `mcp__resources__stripe_get` — **Preferred for all read-only (GET) requests.** Make a GET request to any Stripe API endpoint. Args: `resourceId`, `path`, `query?`
 - `mcp__resources__stripe_list_customers` — List customers with optional email filter and cursor pagination. Args: `resourceId`, `email?`, `limit?`, `startingAfter?`
 - `mcp__resources__stripe_get_customer` — Get a single customer by ID. Args: `resourceId`, `customerId`
 - `mcp__resources__stripe_list_payment_intents` — List payment intents with optional filters. Args: `resourceId`, `customer?`, `status?`, `limit?`, `startingAfter?`
 - `mcp__resources__stripe_get_balance` — Get the current account balance. Args: `resourceId`
 - `mcp__resources__stripe_list_subscriptions` — List subscriptions with optional filters. Args: `resourceId`, `customer?`, `status?`, `limit?`, `startingAfter?`
 - `mcp__resources__stripe_list_invoices` — List invoices with optional filters. Args: `resourceId`, `customer?`, `status?`, `limit?`, `startingAfter?`
-- `mcp__resources__stripe_invoke` — Make any HTTP request (GET/POST/PUT/DELETE) for write operations. Args: `resourceId`, `method`, `path`, `query?`, `headers?`, `body?`, `timeoutMs?`
+- `mcp__resources__stripe_invoke` — Make any HTTP request (GET/POST/PUT/DELETE). **Use only for write operations** (POST/PUT/DELETE) or endpoints not covered by `stripe_get` / `stripe_list_*` / `stripe_get_*`. Args: `resourceId`, `method`, `path`, `query?`, `headers?`, `body?`, `timeoutMs?`
 
 ## TypeScript Client
 


### PR DESCRIPTION
## Summary
- Add explicit tool-selection guidance to the Stripe skill so Claude prefers `stripe_get` (and the specialized `stripe_list_*` / `stripe_get_*` tools) for read-only operations.
- Reframe `stripe_invoke` as write-only, for endpoints not covered by the dedicated GET tools.

## Test plan
- [ ] Reload the stripe skill and confirm Claude reaches for `stripe_get` first on read-only endpoints.
- [ ] Confirm `stripe_invoke` is still used for POST/PUT/DELETE examples in the same skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)