### PR TITLE
chore: add jose, max, and rishikesh as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global owner for all files
-* @jasonzbao
+* @jasonzbao @josegironn @exymax @rishikesh-major


### PR DESCRIPTION
## Summary
- Add @josegironn, @exymax, and @rishikesh-major to CODEOWNERS alongside @jasonzbao so all active contributors are owners of the repo.

## Test plan
- [ ] Confirm GitHub recognizes the new owners on this PR's review request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)