### PR TITLE
docs(ai-proxy skill): document Gemini and image generation

### DIFF
--- a/plugins/shared/skills/resources_ai-proxy/SKILL.md
+++ b/plugins/shared/skills/resources_ai-proxy/SKILL.md
@@ -191,7 +191,7 @@ const imageBytes = imagen.generatedImages?.[0]?.image?.imageBytes;
 ## Rules
 
 - Always use the native provider SDK (`@anthropic-ai/sdk`, `openai`, or `@google/genai`) — never a unified SDK
-- Set the base URL to `process.env.MAJOR_AI_PROXY_URL + "/<provider>"` (`/anthropic`, `/openai`, or `/genai`). For Gemini, this is the SDK's `httpOptions.baseUrl`; for Anthropic and OpenAI, it's `baseURL`.
+- Set the base URL to `MAJOR_AI_PROXY_URL + "/<provider>"` — `/anthropic`, `/openai`, or `/genai`. For Anthropic and OpenAI, this is the SDK's `baseURL`; for Gemini, it's `httpOptions.baseUrl`.
 - **Set `apiKey` to `process.env.MAJOR_JWT_TOKEN`** — this is required for authentication. Without it, all requests will be rejected.
 - Never hardcode API keys or proxy URLs
 - Only use models from the allowlist above

--- a/plugins/shared/skills/resources_ai-proxy/SKILL.md
+++ b/plugins/shared/skills/resources_ai-proxy/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: using-ai-proxy
-description: Use when the user asks to add AI features, LLM calls, or chat functionality to their app. Covers Major's built-in AI proxy for Anthropic and OpenAI APIs.
+description: Use when the user asks to add AI features, LLM calls, or chat functionality to their app. Covers Major's built-in AI proxy for Anthropic, OpenAI, and Gemini APIs.
 ---
 
 ## Major AI Proxy
 
-Major provides a built-in AI proxy that lets apps call Anthropic and OpenAI APIs without configuring API keys. Usage is billed at cost against the user's credits.
+Major provides a built-in AI proxy that lets apps call Anthropic, OpenAI, and Gemini APIs without configuring API keys. Usage is billed at cost against the user's credits.
 
 ## Workflow
 
@@ -82,6 +82,82 @@ const transcription = await client.audio.transcriptions.create({
 });
 ```
 
+### OpenAI — Image Generation
+
+Three stateless endpoints. None persist images server-side — input image bytes only live in the request body.
+
+```typescript
+// Text → image
+const image = await client.images.generate({
+	model: "gpt-image-1",
+	prompt: "A white siamese cat",
+	n: 1,
+	size: "1024x1024",
+});
+
+// Image + prompt → edited image
+const edited = await client.images.edit({
+	model: "gpt-image-1",
+	image: fs.createReadStream("input.png"),
+	prompt: "Add a top hat",
+});
+
+// Image → variations (DALL-E 2 only)
+const variations = await client.images.createVariation({
+	image: fs.createReadStream("input.png"),
+	n: 2,
+});
+```
+
+### Gemini
+
+Use the official `@google/genai` SDK. Point its `baseUrl` at the proxy's `/genai` prefix — the SDK appends `/v1beta/models/...` itself.
+
+```typescript
+import { GoogleGenAI } from "@google/genai";
+
+const ai = new GoogleGenAI({
+	apiKey: process.env.MAJOR_JWT_TOKEN,
+	httpOptions: {
+		baseUrl: process.env.MAJOR_AI_PROXY_URL + "/genai",
+	},
+});
+
+const response = await ai.models.generateContent({
+	model: "gemini-2.5-pro",
+	contents: "Hello!",
+});
+```
+
+Streaming uses `ai.models.generateContentStream(...)` and counting tokens uses `ai.models.countTokens(...)` with the same client.
+
+### Gemini — Image Generation
+
+Two paths: an image-capable model via `generateContent` (output comes back as `inlineData` parts), or the dedicated `generateImages` endpoint for Imagen.
+
+```typescript
+// Gemini image models via generateContent
+const response = await ai.models.generateContent({
+	model: "gemini-2.5-flash-image",
+	contents: "A picture of a banana dish in a fancy restaurant",
+});
+
+for (const part of response.candidates[0].content.parts) {
+	if (part.inlineData) {
+		const dataUrl = `data:image/png;base64,${part.inlineData.data}`;
+	}
+}
+
+// Imagen via generateImages
+const imagen = await ai.models.generateImages({
+	model: "imagen-3.0-generate-002",
+	prompt: "Robot holding a red skateboard",
+	config: { numberOfImages: 1 },
+});
+
+const imageBytes = imagen.generatedImages?.[0]?.image?.imageBytes;
+```
+
 ## Available Models
 
 **Anthropic:**
@@ -99,10 +175,23 @@ const transcription = await client.audio.transcriptions.create({
 - `o3` (reasoning)
 - `o4-mini` (fast reasoning)
 
+**Gemini:**
+
+- `gemini-2.5-pro` (flagship, reasoning)
+- `gemini-2.5-flash` (fast, mid-tier)
+- `gemini-2.5-flash-lite` (cheapest)
+
+**Image generation:**
+
+- `gpt-image-1`, `gpt-image-2` (OpenAI, via `images.generate` / `images.edit`)
+- `dall-e-2` (OpenAI, the only model that supports `images.createVariation`)
+- `gemini-2.5-flash-image`, `gemini-3-pro-image-preview` (Gemini, via `generateContent`)
+- `imagen-3.0-generate-002` (Gemini, via `generateImages`)
+
 ## Rules
 
-- Always use the native provider SDK (Anthropic or OpenAI) — never a unified SDK
-- Set `baseURL` to `process.env.MAJOR_AI_PROXY_URL + "/<provider>"` (e.g. `/anthropic` or `/openai`)
+- Always use the native provider SDK (`@anthropic-ai/sdk`, `openai`, or `@google/genai`) — never a unified SDK
+- Set the base URL to `process.env.MAJOR_AI_PROXY_URL + "/<provider>"` (`/anthropic`, `/openai`, or `/genai`). For Gemini, this is the SDK's `httpOptions.baseUrl`; for Anthropic and OpenAI, it's `baseURL`.
 - **Set `apiKey` to `process.env.MAJOR_JWT_TOKEN`** — this is required for authentication. Without it, all requests will be rejected.
 - Never hardcode API keys or proxy URLs
 - Only use models from the allowlist above
@@ -112,11 +201,15 @@ const transcription = await client.audio.transcriptions.create({
 Only these endpoints are available through the proxy:
 
 - **Anthropic:** `/v1/messages` (chat)
-- **OpenAI:** `/v1/chat/completions` (chat), `/v1/responses` (responses API), `/v1/audio/speech` (text-to-speech), `/v1/audio/transcriptions` (speech-to-text)
+- **OpenAI:** `/v1/chat/completions` (chat), `/v1/responses` (responses API), `/v1/audio/speech` (text-to-speech), `/v1/audio/transcriptions` (speech-to-text), `/v1/images/generations`, `/v1/images/edits`, `/v1/images/variations`
+- **Gemini:** `/v1beta/models/{model}:generateContent`, `/v1beta/models/{model}:streamGenerateContent`, `/v1beta/models/{model}:countTokens`, `/v1beta/models/{model}:generateImages`
+
+All image endpoints are stateless — input image bytes only live in the request body for that one call. There's no Files API, no Assistants/threads, and no server-side persistence.
 
 ## Limitations
 
-- No embeddings or image generation
-- Anthropic and OpenAI only
+- No embeddings or video generation
+- Anthropic, OpenAI, and Gemini only
+- Gemini: chat, streaming, token counting, and image generation only — embeddings, files, video, cached contents, tuning, and the Live API are not supported
 - Monthly spending limits apply — requests are rejected if limit exceeded or wallet empty
 - Specific models from the allowlist only


### PR DESCRIPTION
## Summary

Documents the AI proxy's newly-shipped Gemini support and image generation endpoints. Companion to [mono-builder#1283](https://github.com/major-technology/mono-builder/pull/1283).

## What's new in the skill

- **Gemini provider** — \`@google/genai\` SDK with \`httpOptions.baseUrl\` pointed at \`/genai\`, model list (gemini-2.5-pro / -flash / -flash-lite), streaming and token-counting examples.
- **Image generation** — OpenAI \`images.generate\` / \`images.edit\` / \`images.createVariation\` (gpt-image-1, gpt-image-2, dall-e-2/3) and Gemini \`generateContent\` for image-output models plus \`generateImages\` (Imagen). Notes that all image endpoints are stateless (no Files API, no Assistants/threads).
- **Available Endpoints** — three new OpenAI image paths plus Gemini's \`:generateImages\`.
- **Limitations** — removed the blanket "no image generation" exclusion; Gemini section now explicitly notes embeddings/files/video/cached-contents/tuning/Live API as still unsupported.

## Test plan

- [x] No code change — pure markdown.
- [x] Rules section still mentions the JWT-as-apiKey requirement.
- [x] Provider base URLs match what the matching SDK ergonomics produce (\`/openai\` works for OpenAI Node v5+ since the SDK's resource paths omit \`/v1\`, and the proxy allowlist accepts the bare form too per mono-builder#1283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
