### PR TITLE
http-proxy skill: document the Node/root createProxyFetch entry

### DIFF
--- a/plugins/shared/skills/http-proxy/SKILL.md
+++ b/plugins/shared/skills/http-proxy/SKILL.md
@@ -43,6 +43,22 @@ import { createProxyFetch } from "@major-tech/resource-client/next";
 
 `x-major-user-jwt` is auto-forwarded by reading `headers().get("x-major-user-jwt")` from the incoming Next request, so per-user-OAuth resources (Gmail, Calendar, Drive) work transparently. Outside a Next request scope (e.g. background jobs) the lookup is skipped.
 
+### Non-Next runtimes (plain Node, agent skill scripts)
+
+The `/next` entry imports `next/headers`, so it only loads inside a Next app. In a plain Node runtime — standalone scripts, background workers, agent skill scripts — import `createProxyFetch` from the package ROOT instead:
+
+```typescript
+import { createProxyFetch } from "@major-tech/resource-client";
+```
+
+Same config and behaviour, with one extra optional field, `getUserJwt`, in place of the automatic Next lookup:
+
+| Field        | Type                                                          | Required | Notes                                                                            |
+| ------------ | ------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `getUserJwt` | `() => Promise<string \| null \| undefined> \| string \| ...` | no       | Resolver for `x-major-user-jwt` (per-user-OAuth resources). Omit if you don't need it. |
+
+Most non-Next callers act as the deployment identity and don't have a user JWT, so omit `getUserJwt` entirely — the proxy still injects the resource's shared auth. Only pass it when you must target a specific user's connected account and have a way to fetch their token.
+
 ### Drop-in with a third-party SDK
 
 ```typescript


### PR DESCRIPTION
## What

The `using-http-proxy` skill only documented `@major-tech/resource-client/next`, which imports `next/headers` and won't load outside a Next app. Adds a "Non-Next runtimes" section covering the package-root `createProxyFetch` (plain Node, agent skill scripts), including the optional `getUserJwt` field that deployment-identity callers omit.

Pairs with public-packages #92 (which adds the root export) — depends on `@major-tech/resource-client@0.2.69` being published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
