### PR TITLE
feat(skills): add using-mcp-custom-connector skill for runtime MCP tool calls

### DIFF
--- a/plugins/major/skills/resources_mcp_custom
+++ b/plugins/major/skills/resources_mcp_custom
@@ -1,0 +1,1 @@
+../../shared/skills/resources_mcp_custom

--- a/plugins/shared/skills/resources_mcp_custom/SKILL.md
+++ b/plugins/shared/skills/resources_mcp_custom/SKILL.md
@@ -22,7 +22,7 @@ A custom MCP connector points at an external remote MCP server you bring. Its to
 
 **App context required**: `callTool()` needs the app's `baseUrl` / `applicationId` / JWT, which are injected into the deployed app's environment. In a coding session, reach the connector through the `mcp__<slug>__*` tools instead.
 
-**Error handling**: unlike other resource clients, `callTool()` **throws** `ResourceInvokeError` on a transport failure or an error response — there is **no `result.ok` envelope** to check. Wrap calls in `try/catch`. A tool-level failure that the upstream reports successfully comes back as a normal result with `isError: true`.
+**Return + error handling**: `callTool<T>()` returns the tool's **structured result typed as `T`** directly (it's `undefined` for tools that return only unstructured text). Unlike other resource clients, it **throws** `ResourceInvokeError` on transport failure, an error response, **or** a tool-level error — there is no `result.ok` / `isError` envelope to inspect. Wrap calls in `try/catch`.
 
 ---
 
@@ -43,29 +43,22 @@ const mcp = createMcpClient({
 	majorJwtToken: process.env.MAJOR_JWT_TOKEN!,
 });
 
-// callTool<T>(tool, args?) — `tool` is the upstream MCP tool name; `args` is
-// forwarded verbatim. Throws ResourceInvokeError on transport/server error.
+// callTool<T>(tool, args?) returns the tool's structured result typed as T.
+// `tool` is the upstream MCP tool name; `args` is forwarded verbatim. Throws
+// ResourceInvokeError on transport / server / tool-level errors.
 try {
-	const result = await mcp.callTool<{ tickets: Ticket[] }>(
+	const { tickets } = await mcp.callTool<{ tickets: Ticket[] }>(
 		"search_tickets",
 		{ customerId, limit: 20 },
 	);
-
-	if (result.isError) {
-		// the tool itself reported an error — detail is in result.content
-		console.error(result.content);
-		return;
-	}
-
-	const data = result.structuredContent; // typed as { tickets: Ticket[] } | undefined
-	// or read result.content (text/other blocks) when the tool returns no structured payload
+	// use tickets…
 } catch (err) {
-	// ResourceInvokeError: transport failure or an error envelope from the proxy
+	// ResourceInvokeError — transport failure, error envelope, or tool isError
 }
 ```
 
 ## Tips
 
-- **Result shape** mirrors the MCP `CallToolResult`: read `result.structuredContent` (typed via the `<T>` you pass) for structured payloads, or `result.content` for unstructured blocks; check `result.isError` for tool-level failures.
+- **`callTool<T>` returns the tool's structured result** typed as `T` (the MCP `structuredContent`), or `undefined` if the tool returns only unstructured text. Tool-level errors throw rather than returning a flag.
 - **Args are forwarded verbatim** to the upstream tool — match the upstream server's expected schema exactly.
 - **Auth is injected server-side** using the resolved shared or per-user credential; never set auth headers yourself.

--- a/plugins/shared/skills/resources_mcp_custom/SKILL.md
+++ b/plugins/shared/skills/resources_mcp_custom/SKILL.md
@@ -22,7 +22,7 @@ A custom MCP connector points at an external remote MCP server you bring. Its to
 
 **App context required**: `callTool()` needs the app's `baseUrl` / `applicationId` / JWT, which are injected into the deployed app's environment. In a coding session, reach the connector through the `mcp__<slug>__*` tools instead.
 
-**Return + error handling**: `callTool<T>()` returns the tool's **structured result typed as `T`** directly (it's `undefined` for tools that return only unstructured text). Unlike other resource clients, it **throws** `ResourceInvokeError` on transport failure, an error response, **or** a tool-level error — there is no `result.ok` / `isError` envelope to inspect. Wrap calls in `try/catch`.
+**Error handling**: unlike other resource clients, `callTool()` **throws** `ResourceInvokeError` on a transport failure or an error response — there is **no `result.ok` envelope** to check. Wrap calls in `try/catch`. A tool-level failure that the upstream reports successfully comes back as a normal result with `isError: true`.
 
 ---
 
@@ -43,22 +43,29 @@ const mcp = createMcpClient({
 	majorJwtToken: process.env.MAJOR_JWT_TOKEN!,
 });
 
-// callTool<T>(tool, args?) returns the tool's structured result typed as T.
-// `tool` is the upstream MCP tool name; `args` is forwarded verbatim. Throws
-// ResourceInvokeError on transport / server / tool-level errors.
+// callTool<T>(tool, args?) — `tool` is the upstream MCP tool name; `args` is
+// forwarded verbatim. Throws ResourceInvokeError on transport/server error.
 try {
-	const { tickets } = await mcp.callTool<{ tickets: Ticket[] }>(
+	const result = await mcp.callTool<{ tickets: Ticket[] }>(
 		"search_tickets",
 		{ customerId, limit: 20 },
 	);
-	// use tickets…
+
+	if (result.isError) {
+		// the tool itself reported an error — detail is in result.content
+		console.error(result.content);
+		return;
+	}
+
+	const data = result.structuredContent; // typed as { tickets: Ticket[] } | undefined
+	// or read result.content (text/other blocks) when the tool returns no structured payload
 } catch (err) {
-	// ResourceInvokeError — transport failure, error envelope, or tool isError
+	// ResourceInvokeError: transport failure or an error envelope from the proxy
 }
 ```
 
 ## Tips
 
-- **`callTool<T>` returns the tool's structured result** typed as `T` (the MCP `structuredContent`), or `undefined` if the tool returns only unstructured text. Tool-level errors throw rather than returning a flag.
+- **Result shape** mirrors the MCP `CallToolResult`: read `result.structuredContent` (typed via the `<T>` you pass) for structured payloads, or `result.content` for unstructured blocks; check `result.isError` for tool-level failures.
 - **Args are forwarded verbatim** to the upstream tool — match the upstream server's expected schema exactly.
 - **Auth is injected server-side** using the resolved shared or per-user credential; never set auth headers yourself.

--- a/plugins/shared/skills/resources_mcp_custom/SKILL.md
+++ b/plugins/shared/skills/resources_mcp_custom/SKILL.md
@@ -9,7 +9,7 @@ A custom MCP connector points at an external remote MCP server you bring. Its to
 
 ## Common: Interacting with Resources
 
-**Security**: Never connect directly to the upstream MCP server. Never put credentials in code. The connector's auth is injected server-side using its shared credential.
+**Security**: Never connect directly to the upstream MCP server. Never put credentials in code. The connector's auth is injected server-side using the resolved shared or per-user credential.
 
 **Two ways to interact with a custom MCP connector:**
 
@@ -61,4 +61,4 @@ try {
 - **mcp_custom connectors are callable from app code.** They used to be reachable only through in-session MCP tools; app code can now call their tools at runtime via `MCPResourceClient.callTool()`. Don't tell the user a custom MCP connector "can't be used from the app."
 - **Result shape** mirrors the MCP `CallToolResult`: read `result.structuredContent` (typed via the `<T>` you pass) for structured payloads, or `result.content` for unstructured blocks; check `result.isError` for tool-level failures.
 - **Args are forwarded verbatim** to the upstream tool — match the upstream server's expected schema exactly.
-- **Auth is injected server-side** using the connector's shared credential; never set auth headers yourself.
+- **Auth is injected server-side** using the resolved shared or per-user credential; never set auth headers yourself.

--- a/plugins/shared/skills/resources_mcp_custom/SKILL.md
+++ b/plugins/shared/skills/resources_mcp_custom/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: using-mcp-custom-connector
+description: Implements runtime tool calls to a custom (bring-your-own) remote MCP server connector, using the in-session MCP tools for exploration and a generated MCPResourceClient for app code. Use when doing ANYTHING that touches a custom MCP connector / remote MCP server / mcp_custom resource in any way, load this skill.
+---
+
+# Major Platform Resource: Custom MCP Connector (BYO remote MCP server)
+
+A custom MCP connector points at an external remote MCP server you bring. Its tools are defined by that upstream server, not by Major — so there is **no fixed `mcp__resources__mcp_custom_*` tool set**. The available tools, their names, and their argument shapes all come from the upstream server.
+
+## Common: Interacting with Resources
+
+**Security**: Never connect directly to the upstream MCP server. Never put credentials in code. The connector's auth is injected server-side using its shared credential.
+
+**Two ways to interact with a custom MCP connector:**
+
+1. **In-session MCP tools** (direct, no code needed): the connector is mounted as its own MCP server, so its tools are callable during the build as `mcp__<slug>__<toolName>`. Use `mcp__resources__list_resources` to find the connector and its `resourceId`. Call these tools to discover what the upstream server exposes and to test behavior.
+2. **Generated TypeScript client** (for app code): call `mcp__resource-tools__add-resource-client` with the `resourceId` to generate a typed `MCPResourceClient` in `/clients/` (Next.js) or `/src/clients/` (Vite).
+
+**CRITICAL: Do NOT guess tool names or argument shapes.** They are defined by the upstream MCP server, not by Major or by the generated client (the client exposes a single generic `callTool(name, args)` — it has no per-tool typed methods). Discover the real tool names and arg shapes from the in-session `mcp__<slug>__*` tools before wiring them into app code.
+
+**Framework note**: Next.js = the client must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+
+**App-mode only**: `callTool()` only works from a generated app client (it requires the application context). It is not available to tool- or skill-scoped clients. In a coding session, reach the connector through the `mcp__<slug>__*` tools instead.
+
+**Error handling**: unlike other resource clients, `callTool()` **throws** `ResourceInvokeError` on a transport failure or an error response — there is **no `result.ok` envelope** to check. Wrap calls in `try/catch`. A tool-level failure that the upstream reports successfully comes back as a normal result with `isError: true`.
+
+---
+
+## MCP Tools (in-session)
+
+There is no static tool list. The connector's upstream tools are mounted as `mcp__<slug>__<toolName>`, where `<slug>` is the connector's mount slug. Examples depend entirely on the upstream server (e.g. `mcp__acme__search_tickets`, `mcp__acme__create_ticket`). Use `mcp__resources__list_resources` to find the connector, then call its mounted tools to learn the exact names and arguments.
+
+## TypeScript Client
+
+```typescript
+import { myMcpClient } from "./clients";
+
+// callTool<T>(tool, args?) — `tool` is the upstream MCP tool name; `args` is
+// forwarded verbatim. Throws ResourceInvokeError on transport/server error.
+try {
+	const result = await myMcpClient.callTool<{ tickets: Ticket[] }>(
+		"search_tickets",
+		{ customerId, limit: 20 },
+	);
+
+	if (result.isError) {
+		// the tool itself reported an error — detail is in result.content
+		console.error(result.content);
+		return;
+	}
+
+	const data = result.structuredContent; // typed as { tickets: Ticket[] } | undefined
+	// or read result.content (text/other blocks) when the tool returns no structured payload
+} catch (err) {
+	// ResourceInvokeError: transport failure or an error envelope from the proxy
+}
+```
+
+## Tips
+
+- **mcp_custom connectors are callable from app code.** They used to be reachable only through in-session MCP tools; app code can now call their tools at runtime via `MCPResourceClient.callTool()`. Don't tell the user a custom MCP connector "can't be used from the app."
+- **Result shape** mirrors the MCP `CallToolResult`: read `result.structuredContent` (typed via the `<T>` you pass) for structured payloads, or `result.content` for unstructured blocks; check `result.isError` for tool-level failures.
+- **Args are forwarded verbatim** to the upstream tool — match the upstream server's expected schema exactly.
+- **Auth is injected server-side** using the connector's shared credential; never set auth headers yourself.

--- a/plugins/shared/skills/resources_mcp_custom/SKILL.md
+++ b/plugins/shared/skills/resources_mcp_custom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-mcp-custom-connector
-description: Implements runtime tool calls to a custom (bring-your-own) remote MCP server connector, using the in-session MCP tools for exploration and a generated MCPResourceClient for app code. Use when doing ANYTHING that touches a custom MCP connector / remote MCP server / mcp_custom resource in any way, load this skill.
+description: Implements runtime tool calls to a custom (bring-your-own) remote MCP server connector, using the in-session MCP tools for exploration and the generic createMcpClient for app code. Use when doing ANYTHING that touches a custom MCP connector / remote MCP server / mcp_custom resource in any way, load this skill.
 ---
 
 # Major Platform Resource: Custom MCP Connector (BYO remote MCP server)
@@ -14,13 +14,13 @@ A custom MCP connector points at an external remote MCP server you bring. Its to
 **Two ways to interact with a custom MCP connector:**
 
 1. **In-session MCP tools** (direct, no code needed): the connector is mounted as its own MCP server, so its tools are callable during the build as `mcp__<slug>__<toolName>`. Use `mcp__resources__list_resources` to find the connector and its `resourceId`. Call these tools to discover what the upstream server exposes and to test behavior.
-2. **Generated TypeScript client** (for app code): call `mcp__resource-tools__add-resource-client` with the `resourceId` to generate a typed `MCPResourceClient` in `/clients/` (Next.js) or `/src/clients/` (Vite).
+2. **Generic MCP client** (for app code): import `createMcpClient` from `@major-tech/resource-client/next` and call `.callTool()`. There is **no per-resource generation step** — it's one client reused for any MCP connector; you just pass the `resourceId`.
 
-**CRITICAL: Do NOT guess tool names or argument shapes.** They are defined by the upstream MCP server, not by Major or by the generated client (the client exposes a single generic `callTool(name, args)` — it has no per-tool typed methods). Discover the real tool names and arg shapes from the in-session `mcp__<slug>__*` tools before wiring them into app code.
+**CRITICAL: Do NOT guess tool names or argument shapes.** They are defined by the upstream MCP server, not by Major or by the client — `callTool(name, args)` is a single generic method with no per-tool typed methods. Discover the real tool names and arg shapes from the in-session `mcp__<slug>__*` tools before wiring them into app code.
 
-**Framework note**: Next.js = the client must be used in server-side code only (Server Components, Server Actions, API Routes). Vite = call directly from frontend.
+**Server-side only**: the app JWT must never reach the browser, so call `createMcpClient` from Next server code (Server Components, Server Actions, Route Handlers).
 
-**App-mode only**: `callTool()` only works from a generated app client (it requires the application context). It is not available to tool- or skill-scoped clients. In a coding session, reach the connector through the `mcp__<slug>__*` tools instead.
+**App context required**: `callTool()` needs the app's `baseUrl` / `applicationId` / JWT, which are injected into the deployed app's environment. In a coding session, reach the connector through the `mcp__<slug>__*` tools instead.
 
 **Error handling**: unlike other resource clients, `callTool()` **throws** `ResourceInvokeError` on a transport failure or an error response — there is **no `result.ok` envelope** to check. Wrap calls in `try/catch`. A tool-level failure that the upstream reports successfully comes back as a normal result with `isError: true`.
 
@@ -33,12 +33,20 @@ There is no static tool list. The connector's upstream tools are mounted as `mcp
 ## TypeScript Client
 
 ```typescript
-import { myMcpClient } from "./clients";
+import { createMcpClient } from "@major-tech/resource-client/next";
+
+// Config comes from the deployed app's injected env; resourceId is the connector.
+const mcp = createMcpClient({
+	baseUrl: process.env.MAJOR_API_BASE_URL!,
+	applicationId: process.env.APPLICATION_ID!,
+	resourceId: "<connector resourceId>",
+	majorJwtToken: process.env.MAJOR_JWT_TOKEN!,
+});
 
 // callTool<T>(tool, args?) — `tool` is the upstream MCP tool name; `args` is
 // forwarded verbatim. Throws ResourceInvokeError on transport/server error.
 try {
-	const result = await myMcpClient.callTool<{ tickets: Ticket[] }>(
+	const result = await mcp.callTool<{ tickets: Ticket[] }>(
 		"search_tickets",
 		{ customerId, limit: 20 },
 	);
@@ -58,7 +66,7 @@ try {
 
 ## Tips
 
-- **mcp_custom connectors are callable from app code.** They used to be reachable only through in-session MCP tools; app code can now call their tools at runtime via `MCPResourceClient.callTool()`. Don't tell the user a custom MCP connector "can't be used from the app."
+- **mcp_custom connectors are callable from app code.** They used to be reachable only through in-session MCP tools; app code can now call their tools at runtime via `createMcpClient(...).callTool()`. Don't tell the user a custom MCP connector "can't be used from the app."
 - **Result shape** mirrors the MCP `CallToolResult`: read `result.structuredContent` (typed via the `<T>` you pass) for structured payloads, or `result.content` for unstructured blocks; check `result.isError` for tool-level failures.
 - **Args are forwarded verbatim** to the upstream tool — match the upstream server's expected schema exactly.
 - **Auth is injected server-side** using the resolved shared or per-user credential; never set auth headers yourself.

--- a/plugins/shared/skills/resources_mcp_custom/SKILL.md
+++ b/plugins/shared/skills/resources_mcp_custom/SKILL.md
@@ -66,7 +66,6 @@ try {
 
 ## Tips
 
-- **mcp_custom connectors are callable from app code.** They used to be reachable only through in-session MCP tools; app code can now call their tools at runtime via `createMcpClient(...).callTool()`. Don't tell the user a custom MCP connector "can't be used from the app."
 - **Result shape** mirrors the MCP `CallToolResult`: read `result.structuredContent` (typed via the `<T>` you pass) for structured payloads, or `result.content` for unstructured blocks; check `result.isError` for tool-level failures.
 - **Args are forwarded verbatim** to the upstream tool — match the upstream server's expected schema exactly.
 - **Auth is injected server-side** using the resolved shared or per-user credential; never set auth headers yourself.


### PR DESCRIPTION
Adds an AI-coder skill teaching the agent to call a custom (bring-your-own remote) MCP connector's tools:

- **In-session:** via the mounted `mcp__<slug>__*` tools.
- **App code:** via `createMcpClient(...).callTool()` — one generic client reused for any MCP connector, no per-resource generation.

Captures the differences from other resource skills — server-side-only + app-env config, **throws `ResourceInvokeError`** (no `result.ok` envelope), dynamic upstream tool names — and corrects the now-stale belief that `mcp_custom` connectors can't be used via the API.

Symlinked into the `major` plugin per the shared-skill convention.

Pairs with the runtime endpoint (mono-builder #1574) and the client (public-packages #98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
