### PR TITLE
ci: pin goreleaser to v2.16.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,9 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          # Pinned: v2.17.0 broke S3 blob upload ("could not apply before write"
+          # on the acl path). v2.16.0 was current for the last good release (v1.0.8).
+          version: "v2.16.0"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Pin the goreleaser version in the release workflow to `v2.16.0` instead of floating `latest`.

## Why

The `v1.0.9` release failed. Build, archives, checksums, and the Homebrew formula all succeeded; it died on the first S3 blob upload:

```
⨯ release failed after 43s
  error=blobs: failed to publish artifacts: failed to write to bucket:
  blob (key "1.0.9/major_1.0.9_linux_amd64.tar.gz") (code=Unknown): could not apply before write
```

Root cause is a goreleaser regression, not our config:

- `.goreleaser.yaml` `blobs` block unchanged since Nov 2025.
- Bucket `major-cli-releases` still has ACLs enabled (`BucketOwnerPreferred`), public ACLs not blocked; a manual `put-object --acl public-read` succeeds. So `acl: public-read` is not being rejected.
- The workflow pinned `version: latest`, which floated to **v2.17.0**, whose gocloud S3 writer fails applying the ACL option (`could not apply before write`).

`v2.16.0` was the current release when the last good release (`v1.0.8`, Jun 9) shipped.

## Note

The `v1.0.9` tag and GitHub release already exist from the failed run. After merge, either delete the tag and re-run, or cut `v1.0.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuX8mcHfiDE4niE79YNtXP

Made with [Orca](https://github.com/stablyai/orca) 🐋
