### PR TITLE
fix(release): drop per-object ACL from S3 blob uploads

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,4 +60,7 @@ blobs:
     bucket: major-cli-releases
     region: us-west-1
     directory: "{{ .Version }}"
-    acl: public-read
+    # Public read is served by the bucket policy on major-cli-releases
+    # (terraform/global/releases.tf in mono-builder); goreleaser must not set
+    # per-object ACLs - its ACL upload path regressed under version: latest
+    # and broke the v1.0.9 release twice ("could not apply before write").


### PR DESCRIPTION
The v1.0.9 release failed twice at the S3 publish step with goreleaser's `could not apply before write` — its per-object `acl: public-read` upload path regressed under `version: latest` (the failure happens in goreleaser's ACL callback before any AWS call; binaries built fine both times).

Public read on `major-cli-releases` is already served by the bucket policy (terraform/global/releases.tf in mono-builder), so per-object ACLs are unnecessary as well as broken. This drops the `acl` from the blobs config, with a comment explaining why it must not return.

After merge, re-tag to release: `git tag -d v1.0.9 && git push origin :refs/tags/v1.0.9 && git tag -a v1.0.9 -m v1.0.9 <new-main-sha> && git push origin v1.0.9` (nothing was ever published for v1.0.9 — no GitHub release, no S3 artifacts — so reusing the tag is clean), or just cut v1.0.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sr2JDGa6iLoTHnqwHe7Ltf

Made with [Orca](https://github.com/stablyai/orca) 🐋
