### PR TITLE
docs(graphql): use empty proxy targets

### DIFF
--- a/plugins/shared/skills/resources_graphql/SKILL.md
+++ b/plugins/shared/skills/resources_graphql/SKILL.md
@@ -79,7 +79,7 @@ import { createProxyFetch } from "@major-tech/resource-client/next";
 
 const client = new ApolloClient({
 	link: new HttpLink({
-		uri: "/", // proxy resolves to the resource's configured endpoint
+		uri: () => "", // use the configured endpoint exactly, without adding a slash
 		fetch: createProxyFetch({
 			baseUrl: process.env.MAJOR_API_BASE_URL!,
 			resourceId: "<graphql-resource-id>",
@@ -92,7 +92,7 @@ const client = new ApolloClient({
 
 **Key points:**
 
-- **`uri: "/"`** — the proxy reads the endpoint from the resource at request time; you do not (and should not) hardcode the upstream URL on the client.
+- **Use an empty proxy target** — `proxyFetch("", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ query }) })` uses the configured endpoint exactly, preserving its trailing slash and query parameters. `"/"` appends a slash. In Apollo, use `uri: () => ""`: a plain `uri: ""` falls back to `/graphql`. Do not hardcode the upstream URL.
 - **Auth is injected server-side** — never set `Authorization` on the Apollo link; the proxy strips reserved request headers and replaces them with the resource's configured auth (`bearer`, `apiKey`, or `none`).
 - **Resource ID must be static** — `createProxyFetch` is detected by the query extractor only when `resourceId` is a string literal; dynamic IDs are skipped at deploy time.
 - **Next.js**: use Apollo on the server (RSC, Route Handlers, Server Actions) so the JWT stays out of the browser. For client-side Apollo, route the request through your own server endpoint.

--- a/plugins/shared/skills/resources_graphql/SKILL.md
+++ b/plugins/shared/skills/resources_graphql/SKILL.md
@@ -79,7 +79,7 @@ import { createProxyFetch } from "@major-tech/resource-client/next";
 
 const client = new ApolloClient({
 	link: new HttpLink({
-		uri: () => "", // use the configured endpoint exactly, without adding a slash
+		uri: () => "", // use the configured endpoint without adding a slash
 		fetch: createProxyFetch({
 			baseUrl: process.env.MAJOR_API_BASE_URL!,
 			resourceId: "<graphql-resource-id>",
@@ -92,7 +92,7 @@ const client = new ApolloClient({
 
 **Key points:**
 
-- **Use an empty proxy target** — `proxyFetch("", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ query }) })` uses the configured endpoint exactly, preserving its trailing slash and query parameters. `"/"` appends a slash. In Apollo, use `uri: () => ""`: a plain `uri: ""` falls back to `/graphql`. Do not hardcode the upstream URL.
+- **`proxyFetch("")`** uses the configured endpoint without adding a slash. In Apollo use `uri: () => ""`; plain `uri: ""` falls back to `/graphql`.
 - **Auth is injected server-side** — never set `Authorization` on the Apollo link; the proxy strips reserved request headers and replaces them with the resource's configured auth (`bearer`, `apiKey`, or `none`).
 - **Resource ID must be static** — `createProxyFetch` is detected by the query extractor only when `resourceId` is a string literal; dynamic IDs are skipped at deploy time.
 - **Next.js**: use Apollo on the server (RSC, Route Handlers, Server Actions) so the JWT stays out of the browser. For client-side Apollo, route the request through your own server endpoint.


### PR DESCRIPTION
Use an empty proxy target to call the configured GraphQL endpoint without adding a slash. Show `proxyFetch("")` directly and use `uri: () => ""` with Apollo, whose plain empty-string URI falls back to `/graphql`.

Depends on the companion mono-builder empty-target fix being deployed before this guidance is released.

Validation: checked Apollo's upstream `selectURI` implementation and `git diff --check`. The skill validator could not run because local Python lacks PyYAML; frontmatter is unchanged.
