### PR TITLE
fix: correct PostgreSQL write tool documentation

### DIFF
--- a/plugins/shared/skills/resources_postgresql/SKILL.md
+++ b/plugins/shared/skills/resources_postgresql/SKILL.md
@@ -28,7 +28,7 @@ description: Implements PostgreSQL connections, SQL queries, and migration patte
 
 - `mcp__resources__postgresql_psql` — Execute read-only SQL queries and psql backslash commands (`\dt`, `\d`, `\di`, `\df`, etc.). Args: `resourceId`, `command`, `timeoutMs?`
 - `mcp__resources__postgresql_invoke` — Execute write SQL against managed or external PostgreSQL resources. Args: `resourceId`, `sql`, `params?`, `timeoutMs?`, `description`
-- `mcp__orchestrator-platform__run_migration` — Run tracked migrations on an application's managed database in app-building/orchestrator sessions. Args: `applicationId`, `migration`, `description`
+- `run_migration` on the platform MCP server — Run tracked migrations on an application's managed database in app-building/orchestrator sessions. Args: `applicationId`, `migration`, `description`
 
 ## TypeScript Client
 

--- a/plugins/shared/skills/resources_postgresql/SKILL.md
+++ b/plugins/shared/skills/resources_postgresql/SKILL.md
@@ -28,6 +28,7 @@ description: Implements PostgreSQL connections, SQL queries, and migration patte
 
 - `mcp__resources__postgresql_psql` — Execute read-only SQL queries and psql backslash commands (`\dt`, `\d`, `\di`, `\df`, etc.). Args: `resourceId`, `command`, `timeoutMs?`
 - `mcp__resources__postgresql_invoke` — Execute write SQL against managed or external PostgreSQL resources. Args: `resourceId`, `sql`, `params?`, `timeoutMs?`, `description`
+- `mcp__orchestrator-platform__run_migration` — Run tracked migrations on an application's managed database in app-building/orchestrator sessions. Args: `applicationId`, `migration`, `description`
 
 ## TypeScript Client
 
@@ -48,7 +49,8 @@ if (result.ok) {
 ## Tips
 
 - Use parameterized queries (`$1`, `$2`, ...) — never interpolate values into SQL strings
-- `psql` is read-only; use `postgresql_invoke` for writes against managed or external PostgreSQL resources
+- `psql` is read-only; use `postgresql_invoke` for data modifications against managed or external PostgreSQL resources
+- Use `run_migration` for tracked schema migrations on an application's managed database when the orchestrator tool is available
 - The TypeScript client supports full read/write operations regardless of managed status
 - Use `psql` exclusively for read-only tasks. Never use invoke for read only.
 

--- a/plugins/shared/skills/resources_postgresql/SKILL.md
+++ b/plugins/shared/skills/resources_postgresql/SKILL.md
@@ -49,7 +49,6 @@ if (result.ok) {
 
 - Use parameterized queries (`$1`, `$2`, ...) — never interpolate values into SQL strings
 - `psql` is read-only; use `postgresql_invoke` for writes against managed or external PostgreSQL resources
-- App-building sessions also have a separate, app-scoped `run_migration` orchestrator tool for tracked managed-database schema migrations. It is not a resource tool and must not be called as `mcp__resources__postgresql_run_migration`.
 - The TypeScript client supports full read/write operations regardless of managed status
 - Use `psql` exclusively for read-only tasks. Never use invoke for read only.
 

--- a/plugins/shared/skills/resources_postgresql/SKILL.md
+++ b/plugins/shared/skills/resources_postgresql/SKILL.md
@@ -50,7 +50,7 @@ if (result.ok) {
 
 - Use parameterized queries (`$1`, `$2`, ...) — never interpolate values into SQL strings
 - `psql` is read-only; use `postgresql_invoke` for data modifications against managed or external PostgreSQL resources
-- Use `run_migration` for tracked schema migrations on an application's managed database when the orchestrator tool is available
+- Use `run_migration` for tracked schema migrations on an application's managed database
 - The TypeScript client supports full read/write operations regardless of managed status
 - Use `psql` exclusively for read-only tasks. Never use invoke for read only.
 

--- a/plugins/shared/skills/resources_postgresql/SKILL.md
+++ b/plugins/shared/skills/resources_postgresql/SKILL.md
@@ -27,7 +27,7 @@ description: Implements PostgreSQL connections, SQL queries, and migration patte
 ## MCP Tools
 
 - `mcp__resources__postgresql_psql` — Execute read-only SQL queries and psql backslash commands (`\dt`, `\d`, `\di`, `\df`, etc.). Args: `resourceId`, `command`, `timeoutMs?`
-- `mcp__resources__postgresql_run_migration` — Run DDL/DML migrations on **managed databases only** (`isManaged=true`). Runs in a transaction; rolls back on failure. Args: `resourceId`, `migration`, `description?`
+- `mcp__resources__postgresql_invoke` — Execute write SQL against managed or external PostgreSQL resources. Args: `resourceId`, `sql`, `params?`, `timeoutMs?`, `description`
 
 ## TypeScript Client
 
@@ -48,7 +48,8 @@ if (result.ok) {
 ## Tips
 
 - Use parameterized queries (`$1`, `$2`, ...) — never interpolate values into SQL strings
-- `psql` tool is read-only; use `run_migration` for writes (managed DBs) or the TypeScript client for writes (external DBs)
+- `psql` is read-only; use `postgresql_invoke` for writes against managed or external PostgreSQL resources
+- App-building sessions also have a separate, app-scoped `run_migration` orchestrator tool for tracked managed-database schema migrations. It is not a resource tool and must not be called as `mcp__resources__postgresql_run_migration`.
 - The TypeScript client supports full read/write operations regardless of managed status
 - Use `psql` exclusively for read-only tasks. Never use invoke for read only.
 


### PR DESCRIPTION
## Summary
- document `postgresql_invoke` for ordinary PostgreSQL data modifications
- retain migration guidance using the current app-scoped orchestrator `run_migration` tool
- distinguish resource writes from tracked managed-database migrations

## Context
Cold Email Hackers agent runs needed ordinary UPSERT/INSERT operations but followed the PostgreSQL skill's stale instruction to use the removed `postgresql_run_migration` resource target. The correct resource write tool is `postgresql_invoke`; app-building sessions retain a separate `run_migration` tool for tracked managed-database migrations.

## Validation
- `go test ./...`
- `git diff --check`
