### PR TITLE
Remove run_migration guidance from PostgreSQL skill

### DIFF
--- a/plugins/shared/skills/resources_postgresql/SKILL.md
+++ b/plugins/shared/skills/resources_postgresql/SKILL.md
@@ -28,7 +28,6 @@ description: Implements PostgreSQL connections, SQL queries, and migration patte
 
 - `mcp__resources__postgresql_psql` — Execute read-only SQL queries and psql backslash commands (`\dt`, `\d`, `\di`, `\df`, etc.). Args: `resourceId`, `command`, `timeoutMs?`
 - `mcp__resources__postgresql_invoke` — Execute write SQL against managed or external PostgreSQL resources. Args: `resourceId`, `sql`, `params?`, `timeoutMs?`, `description`
-- `run_migration` on the platform MCP server — Run tracked migrations on an application's managed database in app-building/orchestrator sessions. Args: `applicationId`, `migration`, `description`
 
 ## TypeScript Client
 
@@ -50,7 +49,6 @@ if (result.ok) {
 
 - Use parameterized queries (`$1`, `$2`, ...) — never interpolate values into SQL strings
 - `psql` is read-only; use `postgresql_invoke` for data modifications against managed or external PostgreSQL resources
-- Use `run_migration` for tracked schema migrations on an application's managed database
 - The TypeScript client supports full read/write operations regardless of managed status
 - Use `psql` exclusively for read-only tasks. Never use invoke for read only.
 


### PR DESCRIPTION
## Summary
- remove the `run_migration` MCP tool reference from the PostgreSQL skill
- remove the corresponding migration usage tip

## Testing
- `git diff --check`
- verified no `run_migration` references remain in the file